### PR TITLE
HU-116-Recuperaciones de Mallas en la actualización de malla curricular

### DIFF
--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -511,7 +511,7 @@ export class Malla implements OnInit, OnDestroy {
   }
 
   private async prepareMallaEditMode(): Promise<void> {
-    if (this.selectedUniversidadId === null || this.selectedMallaId === null) {
+    if (this.selectedUniversidadId === null || this.selectedCarreraId === null || this.selectedMallaId === null) {
       return;
     }
 
@@ -525,14 +525,7 @@ export class Malla implements OnInit, OnDestroy {
     this.loadMallasError = false;
 
     try {
-      const carreras = await firstValueFrom(this.carreraService.getCarrerasActivasPorUniversidad(this.selectedUniversidadId));
-      this.carreras = carreras;
-      const mallasPorCarrera = await Promise.all(
-        carreras.map((carrera) => firstValueFrom(this.mallaCatalogoService.getMallasActivasPorCarrera(carrera.id))),
-      );
-
-      const mallasPlanas = mallasPorCarrera.flat();
-      this.mallas = mallasPlanas.filter((malla, index, source) => source.findIndex((candidate) => candidate.id === malla.id) === index);
+      this.mallas = await firstValueFrom(this.mallaCatalogoService.getMallasActivasPorCarrera(this.selectedCarreraId));
 
       if (!this.mallas.some((malla) => malla.id === this.selectedMallaId)) {
         this.selectedMallaId = null;


### PR DESCRIPTION
## Description

This PR updates the malla editing logic to filter the available mallas based on the user’s selected career.

Previously, when entering edit mode, the system loaded all active careers from the selected university and then fetched the mallas for each career to build a general list. Now, the mallas are loaded directly using `selectedCarreraId`, preventing mallas from unrelated careers from being shown.

## Changes Made

- Added validation to ensure a career is selected before preparing the malla edit mode.
- Simplified the logic inside `prepareMallaEditMode()`.
- Replaced the previous flow that loaded mallas from all university careers with a direct lookup by the selected career.
- Prevented mallas from other careers from appearing when editing the student’s malla.

## Result

With this change, the malla selector only displays options related to the selected career, improving form consistency and preventing users from selecting a malla that does not belong to their career.

## Visual Evidence

### Before
The form could load mallas associated with different careers from the same university.
<img width="1856" height="993" alt="image" src="https://github.com/user-attachments/assets/f7c877c0-5b50-4e14-a7cb-3392e32633f0" />

### After
The form now displays only the mallas related to the selected career.
<img width="1852" height="991" alt="image" src="https://github.com/user-attachments/assets/26843153-8fcc-472f-9e5d-b67a6ea87d8b" />