### PR TITLE
HU-133: Validar Fecha de Nacimiento por Rango de Edad

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/estudiante/dto/EstudianteUpdateRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/estudiante/dto/EstudianteUpdateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
+import com.easyschedule.backend.shared.validation.EdadRange;
 
 import java.time.LocalDate;
 
@@ -23,6 +24,7 @@ public record EstudianteUpdateRequest(
 
     @NotNull(message = "La fecha de nacimiento es obligatoria")
     @Past(message = "La fecha de nacimiento debe estar en el pasado")
+    @EdadRange(min = 16, max = 70, message = "La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años")
     LocalDate fechaNacimiento,
 
     @NotNull(message = "El semestre actual es obligatorio")

--- a/backend/src/main/java/com/easyschedule/backend/estudiante/dto/PerfilUpdateRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/estudiante/dto/PerfilUpdateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
+import com.easyschedule.backend.shared.validation.EdadRange;
 
 import java.time.LocalDate;
 
@@ -32,6 +33,7 @@ public record PerfilUpdateRequest(
 
     @NotNull(message = "La fecha de nacimiento es obligatoria")
     @Past(message = "La fecha de nacimiento debe estar en el pasado")
+    @EdadRange(min = 16, max = 70, message = "La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años")
     LocalDate fechaNacimiento,
 
     @Size(max = 120, message = "La carrera no puede exceder 120 caracteres")

--- a/backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRange.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRange.java
@@ -1,0 +1,26 @@
+package com.easyschedule.backend.shared.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = EdadRangeValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EdadRange {
+    String message() default "La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int min();
+
+    int max();
+}

--- a/backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRangeValidator.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRangeValidator.java
@@ -1,0 +1,33 @@
+package com.easyschedule.backend.shared.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+public class EdadRangeValidator implements ConstraintValidator<EdadRange, LocalDate> {
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(EdadRange constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        LocalDate today = LocalDate.now();
+        if (value.isAfter(today)) {
+            return false;
+        }
+
+        int age = Period.between(value, today).getYears();
+        return age >= min && age <= max;
+    }
+}

--- a/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
@@ -104,6 +104,33 @@ class EstudianteControllerTest {
             .andExpect(status().isBadRequest());
     }
 
+    @Test
+    void updateProfileReturnsBadRequestWhenBirthDateIsUnder16() throws Exception {
+        LocalDate under16 = LocalDate.now().minusYears(15);
+        String invalidBody = String.format(
+            """
+            {
+              \"username\": \"diego\",
+              \"nombre\": \"Diego\",
+              \"apellido\": \"Suarez\",
+              \"email\": \"diego@mail.com\",
+              \"carnetIdentidad\": \"123456\",
+              \"fechaNacimiento\": \"%s\",
+              \"carrera\": \"\",
+              \"universidad\": \"\"
+            }
+            """,
+            under16
+        );
+
+        mockMvc.perform(put("/api/estudiantes/perfil/diego")
+                .principal(() -> "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidBody))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años"));
+    }
+
     private EstudianteResponse mockResponse(String username) {
         return new EstudianteResponse(
             1L,

--- a/frontend/src/app/features/perfil/perfil-validators.ts
+++ b/frontend/src/app/features/perfil/perfil-validators.ts
@@ -1,5 +1,11 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
+type DateStruct = {
+  year: number;
+  month: number;
+  day: number;
+};
+
 /**
  * Validador personalizado para el carnet de identidad
  * - Máximo 8 caracteres
@@ -109,6 +115,46 @@ export function emailValidator(): ValidatorFn {
     // Validar longitud máxima
     if (value.length > 100) {
       return { emailMaxLength: { requiredLength: 100, actualLength: value.length } };
+    }
+
+    return null;
+  };
+}
+
+/**
+ * Validador de fecha de nacimiento por rango de edad.
+ */
+export function fechaNacimientoEdadValidator(minAge: number, maxAge: number): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value as DateStruct | null;
+    if (!value) {
+      return null;
+    }
+
+    const birthDate = new Date(value.year, value.month - 1, value.day);
+    if (
+      !Number.isFinite(birthDate.getTime())
+      || birthDate.getFullYear() !== value.year
+      || birthDate.getMonth() !== value.month - 1
+      || birthDate.getDate() !== value.day
+    ) {
+      return { fechaNacimientoInvalid: true };
+    }
+
+    const today = new Date();
+    const normalizedToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    if (birthDate > normalizedToday) {
+      return { fechaNacimientoFuture: true };
+    }
+
+    let age = normalizedToday.getFullYear() - birthDate.getFullYear();
+    const monthDiff = normalizedToday.getMonth() - birthDate.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && normalizedToday.getDate() < birthDate.getDate())) {
+      age--;
+    }
+
+    if (age < minAge || age > maxAge) {
+      return { fechaNacimientoOutOfRange: true };
     }
 
     return null;

--- a/frontend/src/app/features/perfil/perfil.html
+++ b/frontend/src/app/features/perfil/perfil.html
@@ -189,7 +189,7 @@
 						</button>
 					</div>
 					<small class="form-error" *ngIf="editForm.controls.fechaNacimiento.touched && editForm.controls.fechaNacimiento.invalid">
-						{{ 'perfil.validation.required' | translate }}
+						{{ getErrorMessageFechaNacimiento() | translate }}
 					</small>
 				</label>
 			</div>

--- a/frontend/src/app/features/perfil/perfil.spec.ts
+++ b/frontend/src/app/features/perfil/perfil.spec.ts
@@ -191,4 +191,39 @@ describe('Perfil Component', () => {
     expect(toastServiceSpy.error).toHaveBeenCalledWith('perfil.password.error.currentIncorrect');
     expect((component as any).showChangePasswordModal).toBeTrue();
   });
+
+  it('rejects birth date when age is less than 16', () => {
+    fixture.detectChanges();
+
+    const now = new Date();
+    const underageDate = {
+      year: now.getFullYear() - 15,
+      month: now.getMonth() + 1,
+      day: now.getDate(),
+    };
+
+    (component as any).activarEdicion();
+    (component as any).editForm.controls.fechaNacimiento.setValue(underageDate);
+    (component as any).editForm.controls.fechaNacimiento.markAsTouched();
+
+    expect((component as any).editForm.controls.fechaNacimiento.invalid).toBeTrue();
+    expect((component as any).getErrorMessageFechaNacimiento()).toBe('perfil.validation.fechaNacimiento.outOfRange');
+  });
+
+  it('accepts birth date when age is between 16 and 70', () => {
+    fixture.detectChanges();
+
+    const now = new Date();
+    const validDate = {
+      year: now.getFullYear() - 20,
+      month: now.getMonth() + 1,
+      day: now.getDate(),
+    };
+
+    (component as any).activarEdicion();
+    (component as any).editForm.controls.fechaNacimiento.setValue(validDate);
+    (component as any).editForm.controls.fechaNacimiento.markAsTouched();
+
+    expect((component as any).editForm.controls.fechaNacimiento.valid).toBeTrue();
+  });
 });

--- a/frontend/src/app/features/perfil/perfil.ts
+++ b/frontend/src/app/features/perfil/perfil.ts
@@ -11,7 +11,13 @@ import { ToastService } from '../../core/services/toast.service';
 import { SeleccionAcademicaService } from '../../services/academico/seleccion-academica.service';
 import { ChangePasswordRequest, PerfilResponse, PerfilUpdateRequest } from './perfil.model';
 import { PerfilService } from './perfil.service';
-import { carnetIdentidadValidator, nombreValidator, usernameValidator, emailValidator } from './perfil-validators';
+import {
+  carnetIdentidadValidator,
+  nombreValidator,
+  usernameValidator,
+  emailValidator,
+  fechaNacimientoEdadValidator,
+} from './perfil-validators';
 
 type PerfilEditForm = FormGroup<{
   username: FormControl<string>;
@@ -37,6 +43,9 @@ type PasswordChangeForm = FormGroup<{
   styleUrl: './perfil.scss',
 })
 export class Perfil implements OnInit {
+  private static readonly EDAD_MINIMA = 16;
+  private static readonly EDAD_MAXIMA = 70;
+
   protected perfil: PerfilResponse | null = null;
   protected editMode = false;
   protected loading = true;
@@ -48,7 +57,7 @@ export class Perfil implements OnInit {
   protected showCurrentPassword = false;
   protected showNewPassword = false;
   protected showConfirmNewPassword = false;
-  protected readonly fechaNacimientoMinDate: NgbDateStruct = { year: 1950, month: 1, day: 1 };
+  protected readonly fechaNacimientoMinDate: NgbDateStruct;
   protected readonly fechaNacimientoMaxDate: NgbDateStruct;
   protected readonly editForm: PerfilEditForm;
   protected readonly passwordForm: PasswordChangeForm;
@@ -70,11 +79,8 @@ export class Perfil implements OnInit {
     private readonly translateService: TranslateService,
   ) {
     const today = new Date();
-    this.fechaNacimientoMaxDate = {
-      year: today.getFullYear(),
-      month: today.getMonth() + 1,
-      day: today.getDate(),
-    };
+    this.fechaNacimientoMaxDate = this.getBirthDateBoundary(today, Perfil.EDAD_MINIMA);
+    this.fechaNacimientoMinDate = this.getBirthDateBoundary(today, Perfil.EDAD_MAXIMA);
 
     this.editForm = this.fb.group({
       username: this.fb.nonNullable.control('', [Validators.required, usernameValidator()]),
@@ -82,7 +88,7 @@ export class Perfil implements OnInit {
       apellido: this.fb.nonNullable.control('', [Validators.required, nombreValidator()]),
       email: this.fb.nonNullable.control('', [Validators.required, Validators.email, emailValidator()]),
       carnetIdentidad: this.fb.nonNullable.control('', [Validators.required, carnetIdentidadValidator()]),
-      fechaNacimiento: this.fb.control<NgbDateStruct | null>(null, [Validators.required]),
+      fechaNacimiento: this.fb.control<NgbDateStruct | null>(null, [Validators.required, fechaNacimientoEdadValidator(Perfil.EDAD_MINIMA, Perfil.EDAD_MAXIMA)]),
       carrera: this.fb.nonNullable.control(''),
       universidad: this.fb.nonNullable.control(''),
     }) as PerfilEditForm;
@@ -401,6 +407,14 @@ export class Perfil implements OnInit {
       .trim();
   }
 
+  private getBirthDateBoundary(referenceDate: Date, age: number): NgbDateStruct {
+    return {
+      year: referenceDate.getFullYear() - age,
+      month: referenceDate.getMonth() + 1,
+      day: referenceDate.getDate(),
+    };
+  }
+
   protected getNombreCompleto(): string {
     if (!this.perfil) {
       return '';
@@ -548,6 +562,28 @@ export class Perfil implements OnInit {
     }
 
     return '';
+  }
+
+  protected getErrorMessageFechaNacimiento(): string {
+    const control = this.editForm.controls.fechaNacimiento;
+
+    if (!control.touched || !control.errors) {
+      return '';
+    }
+
+    if (control.errors['required']) {
+      return 'perfil.validation.required';
+    }
+
+    if (control.errors['fechaNacimientoFuture']) {
+      return 'perfil.validation.fechaNacimiento.future';
+    }
+
+    if (control.errors['fechaNacimientoOutOfRange']) {
+      return 'perfil.validation.fechaNacimiento.outOfRange';
+    }
+
+    return 'perfil.validation.fechaNacimiento.invalid';
   }
 
   protected getErrorMessageNombre(): string {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -389,6 +389,11 @@
       },
       "email": {
         "maxLength": "Email cannot exceed 100 characters."
+      },
+      "fechaNacimiento": {
+        "future": "Birth date cannot be in the future.",
+        "outOfRange": "Birth date must correspond to an age between 16 and 70 years.",
+        "invalid": "Enter a valid birth date."
       }
     },
     "success": {

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -389,6 +389,11 @@
       },
       "email": {
         "maxLength": "El correo electrónico no puede exceder 100 caracteres."
+      },
+      "fechaNacimiento": {
+        "future": "La fecha de nacimiento no puede estar en el futuro.",
+        "outOfRange": "La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años.",
+        "invalid": "Ingresa una fecha de nacimiento válida."
       }
     },
     "success": {

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -390,6 +390,11 @@
       },
       "email": {
         "maxLength": "O email não pode exceder 100 caracteres."
+      },
+      "fechaNacimiento": {
+        "future": "A data de nascimento não pode estar no futuro.",
+        "outOfRange": "A data de nascimento deve corresponder a uma idade entre 16 e 70 anos.",
+        "invalid": "Informe uma data de nascimento válida."
       }
     },
     "success": {


### PR DESCRIPTION
# PR - HU-133: Validar Fecha de Nacimiento por Rango de Edad

## Contexto

Esta historia fortalece la validacion de fecha de nacimiento en el perfil para evitar edades incoherentes en el contexto universitario.

Antes solo se validaba que la fecha exista y que no sea futura (backend con `@Past`). Ahora se aplica una regla completa y consistente entre frontend y backend con rango de edad permitido.

## Historia de Usuario

**Como** estudiante autenticado  
**Quiero** que la fecha de nacimiento se valide con limites razonables  
**Para** evitar perfiles con edades incoherentes para el contexto universitario

## Criterios implementados

- No se permite fecha futura.
- Se permite unicamente edad entre **16 y 70 años**.
- Si la fecha esta fuera de rango, se muestra mensaje claro y no permite guardar.
- Frontend y backend validan con la misma regla.
- Backend bloquea persistencia cuando no cumple.

## Cambios funcionales

### Frontend

- El datepicker ahora usa limites dinamicos:
  - Minimo: hoy - 70 años.
  - Maximo: hoy - 16 años.
- Se agrega validador de edad para:
  - fecha invalida,
  - fecha futura,
  - edad fuera de rango.
- Se muestran mensajes especificos bajo el campo de fecha.

### Backend

- Se implementa validacion custom reusable de rango de edad (`@EdadRange`).
- Se aplica en ambos DTOs de actualizacion de estudiante/perfil.
- Se mantiene `@Past` y se complementa con el rango 16-70.

## Cambios tecnicos

### Frontend

Archivos modificados:

- `frontend/src/app/features/perfil/perfil-validators.ts`
- `frontend/src/app/features/perfil/perfil.ts`
- `frontend/src/app/features/perfil/perfil.html`
- `frontend/src/app/features/perfil/perfil.spec.ts`
- `frontend/src/assets/i18n/es.json`
- `frontend/src/assets/i18n/en.json`
- `frontend/src/assets/i18n/pt.json`

Implementacion destacada:

- Nuevo validador: `fechaNacimientoEdadValidator(minAge, maxAge)`.
- Nuevo helper en componente para mensaje de error: `getErrorMessageFechaNacimiento()`.
- Integracion del mensaje en template.
- Nuevas claves i18n para:
  - `perfil.validation.fechaNacimiento.future`
  - `perfil.validation.fechaNacimiento.outOfRange`
  - `perfil.validation.fechaNacimiento.invalid`

### Backend

Archivos nuevos:

- `backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRange.java`
- `backend/src/main/java/com/easyschedule/backend/shared/validation/EdadRangeValidator.java`

Archivos modificados:

- `backend/src/main/java/com/easyschedule/backend/estudiante/dto/PerfilUpdateRequest.java`
- `backend/src/main/java/com/easyschedule/backend/estudiante/dto/EstudianteUpdateRequest.java`
- `backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java`

Implementacion destacada:

- Anotacion `@EdadRange(min = 16, max = 70)` aplicada sobre `fechaNacimiento`.
- Mensaje estandar: `La fecha de nacimiento debe corresponder a una edad entre 16 y 70 años`.

## Pruebas ejecutadas

### Frontend

Comando:

```bash
npm test -- --watch=false --browsers=ChromeHeadless --include="src/app/features/perfil/perfil.spec.ts"
```

Resultado:

- 8 tests ejecutados
- 8 tests exitosos

### Backend

Comando:

```bash
./gradlew test --tests "com.easyschedule.backend.estudiante.controller.EstudianteControllerTest"
```

Resultado:

- Build exitoso
- Tests en verde

## Validacion manual sugerida (QA)

- [ ] Intentar guardar fecha futura -> debe rechazar.
- [ ] Intentar guardar con 15 anos -> debe rechazar.
- [ ] Intentar guardar con 16 anos exactos -> debe permitir.
- [ ] Intentar guardar con 70 años -> debe permitir.
- [ ] Intentar guardar con mas de 70 años -> debe rechazar.
- [ ] Verificar que el mensaje de error sea claro y visible.

## Evidencia visual

<img width="470" height="636" alt="image" src="https://github.com/user-attachments/assets/c9494a58-c88a-482a-b1ba-f685e7b2894b" />

<img width="302" height="457" alt="image" src="https://github.com/user-attachments/assets/5654be8a-bbe3-45bb-9bd6-1360c032211e" />

## Impacto y riesgo

- **Impacto esperado:** Bajo, acotado a validacion del campo `fechaNacimiento`.
- **Riesgo principal:** usuarios con datos fuera de rango podrian no poder guardar hasta corregir fecha.
- **Mitigacion:** feedback claro en frontend + rechazo consistente en backend.
