### PR TITLE
HU-134: Contrasena segura en Registro con checklist visible

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/auth/dto/RegistroRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/auth/dto/RegistroRequest.java
@@ -2,9 +2,14 @@ package com.easyschedule.backend.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import com.easyschedule.backend.shared.validation.PasswordPolicy;
 
 public record RegistroRequest(
     @NotBlank(message = "El nombre de usuario no puede estar vacio") String username,
-    @NotBlank(message = "La contrasenia no puede estar vacia") String password,
+    @NotBlank(message = "La contrasenia no puede estar vacia")
+    @Size(min = 8, max = 120, message = "La contrasenia debe tener entre 8 y 120 caracteres")
+    @PasswordPolicy
+    String password,
     @NotBlank(message = "El correo no puede estar vacio") @Email(message = "El formato del correo electronico no es valido") String email
 ) {}

--- a/backend/src/main/java/com/easyschedule/backend/auth/dto/request/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/auth/dto/request/ChangePasswordRequest.java
@@ -2,6 +2,7 @@ package com.easyschedule.backend.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import com.easyschedule.backend.shared.validation.PasswordPolicy;
 
 public class ChangePasswordRequest {
 
@@ -11,6 +12,7 @@ public class ChangePasswordRequest {
 
     @NotBlank(message = "La nueva contrasenia es obligatoria")
     @Size(min = 8, max = 120, message = "La nueva contrasenia debe tener entre 8 y 120 caracteres")
+    @PasswordPolicy(message = "La nueva contrasenia debe tener minimo 8 caracteres, incluir una mayuscula, una minuscula, un numero y un caracter especial")
     private String newPassword;
 
     @NotBlank(message = "Debes repetir la nueva contrasenia")

--- a/backend/src/main/java/com/easyschedule/backend/auth/dto/request/SignupRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/auth/dto/request/SignupRequest.java
@@ -2,6 +2,7 @@
 package com.easyschedule.backend.auth.dto.request;
 
 import jakarta.validation.constraints.*;
+import com.easyschedule.backend.shared.validation.PasswordPolicy;
  
 public class SignupRequest {
     @NotBlank
@@ -14,7 +15,8 @@ public class SignupRequest {
     private String email;
 
     @NotBlank
-    @Size(min = 6, max = 40)
+    @Size(min = 8, max = 120)
+    @PasswordPolicy
     private String password;
   
     public String getUsername() {

--- a/backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicy.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicy.java
@@ -1,0 +1,22 @@
+package com.easyschedule.backend.shared.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = PasswordPolicyValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PasswordPolicy {
+    String message() default "La contrasenia debe tener minimo 8 caracteres, incluir una mayuscula, una minuscula, un numero y un caracter especial";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicyValidator.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicyValidator.java
@@ -1,0 +1,26 @@
+package com.easyschedule.backend.shared.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordPolicyValidator implements ConstraintValidator<PasswordPolicy, String> {
+    private static final int MIN_LENGTH = 8;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+
+        boolean hasUppercase = value.chars().anyMatch(Character::isUpperCase);
+        boolean hasLowercase = value.chars().anyMatch(Character::isLowerCase);
+        boolean hasDigit = value.chars().anyMatch(Character::isDigit);
+        boolean hasSpecial = value.chars().anyMatch(ch -> !Character.isLetterOrDigit(ch));
+
+        return value.length() >= MIN_LENGTH
+            && hasUppercase
+            && hasLowercase
+            && hasDigit
+            && hasSpecial;
+    }
+}

--- a/backend/src/test/java/com/easyschedule/backend/auth/controllers/AuthControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/auth/controllers/AuthControllerTest.java
@@ -43,7 +43,7 @@ class AuthControllerTest {
                 {
                   "username": "newuser",
                   "email": "newuser@mail.com",
-                  "password": "123456"
+                  "password": "Abcd1234!"
                 }
                 """;
 
@@ -65,7 +65,7 @@ class AuthControllerTest {
                 {
                   "username": "duplicate",
                   "email": "duplicate@mail.com",
-                  "password": "123456"
+                  "password": "Abcd1234!"
                 }
                 """;
 
@@ -95,12 +95,30 @@ class AuthControllerTest {
     }
 
     @Test
+    void registerUserReturnsBadRequestWhenPasswordIsWeak() throws Exception {
+        String requestBody = """
+                {
+                  "username": "newuser",
+                  "email": "newuser@mail.com",
+                  "password": "abcd1234"
+                }
+                """;
+
+        mockMvc.perform(post("/api/registro")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+
+        verify(authService, never()).registerUser(any(SignupRequest.class));
+    }
+
+    @Test
     void changePasswordReturnsOkWhenRequestIsValid() throws Exception {
         String requestBody = """
                 {
                   "currentPassword": "actual1234",
-                  "newPassword": "nuevaPassword123",
-                  "confirmNewPassword": "nuevaPassword123"
+                  "newPassword": "NuevaPassword123!",
+                  "confirmNewPassword": "NuevaPassword123!"
                 }
                 """;
 
@@ -109,5 +127,22 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void changePasswordReturnsBadRequestWhenNewPasswordIsWeak() throws Exception {
+        String requestBody = """
+                {
+                  "currentPassword": "actual1234",
+                  "newPassword": "nuevapassword123",
+                  "confirmNewPassword": "nuevapassword123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/change-password")
+                        .principal(() -> "19")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/easyschedule/backend/auth/integration/AuthRegistrationIntegrationTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/auth/integration/AuthRegistrationIntegrationTest.java
@@ -52,7 +52,7 @@ class AuthRegistrationIntegrationTest {
                 {
                   "username": "integration_user",
                   "email": "integration_user@mail.com",
-                  "password": "123456"
+                  "password": "Abcd1234!"
                 }
                 """;
 
@@ -64,19 +64,19 @@ class AuthRegistrationIntegrationTest {
         User createdUser = userRepository.findByUsername("integration_user").orElseThrow();
 
         assertNotNull(createdUser.getId());
-        assertTrue(passwordEncoder.matches("123456", createdUser.getPasswordHash()));
+        assertTrue(passwordEncoder.matches("Abcd1234!", createdUser.getPasswordHash()));
     }
 
     @Test
     void registerEndpointReturnsConflictWhenUsernameAlreadyExists() throws Exception {
-        User existing = new User("integration_user", "first@mail.com", passwordEncoder.encode("123456"));
+        User existing = new User("integration_user", "first@mail.com", passwordEncoder.encode("Abcd1234!"));
         userRepository.save(existing);
 
         String requestBody = """
                 {
                   "username": "integration_user",
                   "email": "second@mail.com",
-                  "password": "123456"
+                  "password": "Abcd1234!"
                 }
                 """;
 
@@ -85,5 +85,22 @@ class AuthRegistrationIntegrationTest {
                         .content(requestBody))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("Error: El nombre de usuario ya está en uso"));
+    }
+
+    @Test
+    void registerEndpointReturnsBadRequestWhenPasswordIsWeak() throws Exception {
+        String requestBody = """
+                {
+                  "username": "integration_user",
+                  "email": "integration_user@mail.com",
+                  "password": "abcd1234"
+                }
+                """;
+
+        mockMvc.perform(post("/api/registro")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
     }
 }

--- a/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,6 +40,40 @@ class EstudianteControllerTest {
 
     @MockitoBean
     private BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter;
+
+    @Test
+    void registerReturnsCreatedWhenRequestIsValid() throws Exception {
+        when(estudianteService.register(any())).thenReturn(mockResponse("diego"));
+
+        String requestBody = """
+            {
+              "username": "diego",
+              "email": "diego@mail.com",
+              "password": "Abcd1234!"
+            }
+            """;
+
+        mockMvc.perform(post("/api/estudiantes/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void registerReturnsBadRequestWhenPasswordIsWeak() throws Exception {
+        String requestBody = """
+            {
+              "username": "diego",
+              "email": "diego@mail.com",
+              "password": "abcd1234"
+            }
+            """;
+
+        mockMvc.perform(post("/api/estudiantes/registro")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest());
+    }
 
     @Test
     void findProfileByUsernameReturnsOk() throws Exception {

--- a/frontend/src/app/features/perfil/perfil.html
+++ b/frontend/src/app/features/perfil/perfil.html
@@ -240,6 +240,16 @@
 					<small class="form-error" *ngIf="passwordForm.controls.newPassword.touched && passwordForm.controls.newPassword.errors?.['minlength']">
 						{{ 'perfil.password.validation.minLength' | translate }}
 					</small>
+					<ul class="password-checklist">
+						<li [class.ok]="getPasswordPolicyChecklist().minLength">{{ 'perfil.password.validation.checklist.minLength' | translate }}</li>
+						<li [class.ok]="getPasswordPolicyChecklist().uppercase">{{ 'perfil.password.validation.checklist.uppercase' | translate }}</li>
+						<li [class.ok]="getPasswordPolicyChecklist().lowercase">{{ 'perfil.password.validation.checklist.lowercase' | translate }}</li>
+						<li [class.ok]="getPasswordPolicyChecklist().number">{{ 'perfil.password.validation.checklist.number' | translate }}</li>
+						<li [class.ok]="getPasswordPolicyChecklist().special">{{ 'perfil.password.validation.checklist.special' | translate }}</li>
+					</ul>
+					<small class="form-error" *ngIf="passwordForm.controls.newPassword.touched && passwordForm.controls.newPassword.errors?.['weakPassword']">
+						{{ 'perfil.password.validation.weakPolicy' | translate }}
+					</small>
 				</label>
 
 				<label class="perfil-field">

--- a/frontend/src/app/features/perfil/perfil.scss
+++ b/frontend/src/app/features/perfil/perfil.scss
@@ -401,6 +401,36 @@
 	margin-top: 0.2rem;
 }
 
+.password-checklist {
+	margin: 0.15rem 0 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	gap: 0.14rem;
+}
+
+.password-checklist li {
+	font-size: 0.74rem;
+	line-height: 1.2;
+	color: #7a4d4d;
+}
+
+.password-checklist li::before {
+	content: '\2715';
+	margin-right: 0.35rem;
+	color: #b44a4a;
+	font-size: 0.66rem;
+}
+
+.password-checklist li.ok {
+	color: #2e6d43;
+}
+
+.password-checklist li.ok::before {
+	content: '\2713';
+	color: #2e6d43;
+}
+
 .perfil-modal__icon {
 	width: 3rem;
 	height: 3rem;

--- a/frontend/src/app/features/perfil/perfil.spec.ts
+++ b/frontend/src/app/features/perfil/perfil.spec.ts
@@ -158,16 +158,16 @@ describe('Perfil Component', () => {
     (component as any).abrirCambioContrasenia();
     (component as any).passwordForm.patchValue({
       currentPassword: 'actual1234',
-      newPassword: 'nueva1234',
-      confirmNewPassword: 'nueva1234',
+      newPassword: 'Nueva1234!',
+      confirmNewPassword: 'Nueva1234!',
     });
 
     (component as any).guardarCambioContrasenia();
 
     expect(perfilServiceSpy.changePassword).toHaveBeenCalledWith({
-      currentPassword: 'actual1234',
-      newPassword: 'nueva1234',
-      confirmNewPassword: 'nueva1234',
+        currentPassword: 'actual1234',
+        newPassword: 'Nueva1234!',
+        confirmNewPassword: 'Nueva1234!',
     });
     expect(toastServiceSpy.success).toHaveBeenCalledWith('perfil.password.success.updated');
     expect((component as any).showChangePasswordModal).toBeFalse();
@@ -182,13 +182,27 @@ describe('Perfil Component', () => {
     (component as any).abrirCambioContrasenia();
     (component as any).passwordForm.patchValue({
       currentPassword: 'incorrecta',
-      newPassword: 'nueva1234',
-      confirmNewPassword: 'nueva1234',
+      newPassword: 'Nueva1234!',
+      confirmNewPassword: 'Nueva1234!',
     });
 
     (component as any).guardarCambioContrasenia();
 
     expect(toastServiceSpy.error).toHaveBeenCalledWith('perfil.password.error.currentIncorrect');
     expect((component as any).showChangePasswordModal).toBeTrue();
+  });
+
+  it('marks new password as invalid when it does not meet policy', () => {
+    fixture.detectChanges();
+
+    (component as any).abrirCambioContrasenia();
+    (component as any).passwordForm.patchValue({
+      currentPassword: 'actual1234',
+      newPassword: 'nuevapassword123',
+      confirmNewPassword: 'nuevapassword123',
+    });
+
+    expect((component as any).passwordForm.controls.newPassword.invalid).toBeTrue();
+    expect((component as any).passwordForm.controls.newPassword.errors?.['weakPassword']).toBeTrue();
   });
 });

--- a/frontend/src/app/features/perfil/perfil.ts
+++ b/frontend/src/app/features/perfil/perfil.ts
@@ -30,6 +30,14 @@ type PasswordChangeForm = FormGroup<{
   confirmNewPassword: FormControl<string>;
 }>;
 
+type PasswordPolicyChecklist = {
+  minLength: boolean;
+  uppercase: boolean;
+  lowercase: boolean;
+  number: boolean;
+  special: boolean;
+};
+
 @Component({
   selector: 'app-perfil',
   imports: [CommonModule, ReactiveFormsModule, NgbDatepickerModule, TranslatePipe, NgbPopoverModule],
@@ -90,7 +98,7 @@ export class Perfil implements OnInit {
     this.passwordForm = this.fb.group(
       {
         currentPassword: this.fb.nonNullable.control('', [Validators.required]),
-        newPassword: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(8)]),
+        newPassword: this.fb.nonNullable.control('', [Validators.required, Validators.minLength(8), this.passwordPolicyValidator]),
         confirmNewPassword: this.fb.nonNullable.control('', [Validators.required]),
       },
       { validators: this.passwordsMatchValidator },
@@ -286,6 +294,11 @@ export class Perfil implements OnInit {
 
         if (backendMessage.includes('contrasenia actual es incorrecta') || backendMessage.includes('contrasena actual es incorrecta')) {
           this.toastService.error('perfil.password.error.currentIncorrect');
+          return;
+        }
+
+        if (backendMessage.includes('mayuscula') || backendMessage.includes('minuscula') || backendMessage.includes('caracter especial')) {
+          this.toastService.error('perfil.password.error.weakPolicy');
           return;
         }
 
@@ -637,5 +650,34 @@ export class Perfil implements OnInit {
     }
 
     return newPassword === confirmNewPassword ? null : { passwordMismatch: true };
+  };
+
+  protected getPasswordPolicyChecklist(): PasswordPolicyChecklist {
+    const newPassword = String(this.passwordForm.controls.newPassword.value ?? '');
+
+    return {
+      minLength: newPassword.length >= 8,
+      uppercase: /[A-Z]/.test(newPassword),
+      lowercase: /[a-z]/.test(newPassword),
+      number: /\d/.test(newPassword),
+      special: /[^A-Za-z0-9]/.test(newPassword),
+    };
+  }
+
+  private passwordPolicyValidator = (control: FormControl<string>): ValidationErrors | null => {
+    const password = String(control.value ?? '');
+    if (!password) {
+      return null;
+    }
+
+    const checklist = {
+      minLength: password.length >= 8,
+      uppercase: /[A-Z]/.test(password),
+      lowercase: /[a-z]/.test(password),
+      number: /\d/.test(password),
+      special: /[^A-Za-z0-9]/.test(password),
+    };
+
+    return Object.values(checklist).every(Boolean) ? null : { weakPassword: true };
   };
 }

--- a/frontend/src/app/features/registro/registro.html
+++ b/frontend/src/app/features/registro/registro.html
@@ -55,6 +55,28 @@
           <small class="form-error"
             *ngIf="form.get('password')?.touched && form.get('password')?.errors?.['minlength']">{{
             'registro.validation.passwordMin' | translate }}</small>
+
+          <ul class="password-checklist">
+            <li [class.ok]="getPasswordChecklist().minLength">
+              {{ 'registro.validation.passwordChecklist.minLength' | translate }}
+            </li>
+            <li [class.ok]="getPasswordChecklist().uppercase">
+              {{ 'registro.validation.passwordChecklist.uppercase' | translate }}
+            </li>
+            <li [class.ok]="getPasswordChecklist().lowercase">
+              {{ 'registro.validation.passwordChecklist.lowercase' | translate }}
+            </li>
+            <li [class.ok]="getPasswordChecklist().number">
+              {{ 'registro.validation.passwordChecklist.number' | translate }}
+            </li>
+            <li [class.ok]="getPasswordChecklist().special">
+              {{ 'registro.validation.passwordChecklist.special' | translate }}
+            </li>
+          </ul>
+
+          <small class="form-error" *ngIf="form.get('password')?.touched && form.get('password')?.errors?.['weakPassword']">
+            {{ 'registro.validation.passwordWeak' | translate }}
+          </small>
         </div>
 
         <div class="form-group">

--- a/frontend/src/app/features/registro/registro.scss
+++ b/frontend/src/app/features/registro/registro.scss
@@ -355,3 +355,34 @@ small {
     margin-bottom: 1.2rem;
   }
 }
+
+.password-checklist {
+  margin: 0.1rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.16rem;
+
+  li {
+    font-size: 0.72rem;
+    color: #7a4d4d;
+    font-family: 'Nunito Sans', sans-serif;
+    line-height: 1.2;
+
+    &::before {
+      content: '\2715';
+      margin-right: 0.35rem;
+      color: #b44a4a;
+      font-size: 0.66rem;
+    }
+
+    &.ok {
+      color: #2e6d43;
+
+      &::before {
+        content: '\2713';
+        color: #2e6d43;
+      }
+    }
+  }
+}

--- a/frontend/src/app/features/registro/registro.spec.ts
+++ b/frontend/src/app/features/registro/registro.spec.ts
@@ -67,8 +67,8 @@ describe('Registro Component', () => {
     component.form.setValue({
       nombre: 'Eduardo',
       correo: 'test@test.com',
-      password: '12345678',
-      confirmPassword: '12345678'
+      password: 'Abcd1234!',
+      confirmPassword: 'Abcd1234!'
     });
 
     component.registrar();
@@ -88,8 +88,8 @@ describe('Registro Component', () => {
     component.form.setValue({
       nombre: 'Eduardo',
       correo: 'test@test.com',
-      password: '12345678',
-      confirmPassword: '12345678'
+      password: 'Abcd1234!',
+      confirmPassword: 'Abcd1234!'
     });
 
     component.registrar();
@@ -115,6 +115,31 @@ describe('Registro Component', () => {
     expect(component.showConfirmPassword).toBeFalse();
     component.toggleConfirmPasswordVisibility();
     expect(component.showConfirmPassword).toBeTrue();
+  });
+
+  it('no debería enviar registro con password débil', () => {
+    component.form.setValue({
+      nombre: 'Eduardo',
+      correo: 'test@test.com',
+      password: 'abcd1234',
+      confirmPassword: 'abcd1234'
+    });
+
+    component.registrar();
+
+    httpMock.expectNone(registerUrl);
+    expect(component.form.invalid).toBeTrue();
+  });
+
+  it('debería marcar checklist de contraseña fuerte correctamente', () => {
+    component.form.patchValue({ password: 'Abcd1234!' });
+
+    const checklist = (component as any).getPasswordChecklist();
+    expect(checklist.minLength).toBeTrue();
+    expect(checklist.uppercase).toBeTrue();
+    expect(checklist.lowercase).toBeTrue();
+    expect(checklist.number).toBeTrue();
+    expect(checklist.special).toBeTrue();
   });
 
 });

--- a/frontend/src/app/features/registro/registro.ts
+++ b/frontend/src/app/features/registro/registro.ts
@@ -14,6 +14,14 @@ import { ApiService } from '../../services/api.service';
 import { AuthSessionService } from '../../core/services/auth-session.service';
 import { ToastService } from '../../core/services/toast.service';
 
+type PasswordChecklist = {
+  minLength: boolean;
+  uppercase: boolean;
+  lowercase: boolean;
+  number: boolean;
+  special: boolean;
+};
+
 @Component({
   selector: 'app-registro',
   standalone: true,
@@ -49,7 +57,7 @@ export class Registro {
     this.form = this.fb.group({
       nombre: ['', Validators.required],
       correo: ['', [Validators.required, Validators.email]],
-      password: ['', [Validators.required, Validators.minLength(8)]],
+      password: ['', [Validators.required, Validators.minLength(8), this.passwordPolicyValidator]],
       confirmPassword: ['', Validators.required],
     }, { validators: this.passwordMatch });
 
@@ -77,7 +85,10 @@ export class Registro {
 
   registrar() {
 
-    if (this.form.invalid) return;
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
 
     this.loading = true;
     this.successMessageKey = '';
@@ -125,8 +136,13 @@ export class Registro {
           this.errorMessageKey = 'registro.error.emailExists';
           this.toastService.error('registro.error.emailExists');
         } else if (err.status === 400) {
-          this.errorMessageKey = 'registro.error.invalidData';
-          this.toastService.error('registro.error.invalidData');
+          if (backendMessage.includes('contrasenia') || backendMessage.includes('password')) {
+            this.errorMessageKey = 'registro.error.weakPassword';
+            this.toastService.error('registro.error.weakPassword');
+          } else {
+            this.errorMessageKey = 'registro.error.invalidData';
+            this.toastService.error('registro.error.invalidData');
+          }
         } else if (err.status === 0) {
           this.errorMessageKey = 'registro.error.backendConnection';
           this.toastService.error('registro.error.backendConnection');
@@ -162,5 +178,35 @@ export class Registro {
 
     return '';
   }
+
+  protected getPasswordChecklist(): PasswordChecklist {
+    const password = String(this.form.get('password')?.value ?? '');
+
+    return {
+      minLength: password.length >= 8,
+      uppercase: /[A-Z]/.test(password),
+      lowercase: /[a-z]/.test(password),
+      number: /\d/.test(password),
+      special: /[^A-Za-z0-9]/.test(password),
+    };
+  }
+
+  private passwordPolicyValidator = (control: AbstractControl): ValidationErrors | null => {
+    const password = String(control.value ?? '');
+    if (!password) {
+      return null;
+    }
+
+    const checklist = {
+      minLength: password.length >= 8,
+      uppercase: /[A-Z]/.test(password),
+      lowercase: /[a-z]/.test(password),
+      number: /\d/.test(password),
+      special: /[^A-Za-z0-9]/.test(password),
+    };
+
+    const isValid = Object.values(checklist).every(Boolean);
+    return isValid ? null : { weakPassword: true };
+  };
 
 }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -408,7 +408,15 @@
       },
       "validation": {
         "minLength": "The new password must be at least 8 characters long.",
-        "mismatch": "The new password and confirmation do not match."
+        "mismatch": "The new password and confirmation do not match.",
+        "weakPolicy": "The new password does not meet the security policy.",
+        "checklist": {
+          "minLength": "At least 8 characters",
+          "uppercase": "At least 1 uppercase letter",
+          "lowercase": "At least 1 lowercase letter",
+          "number": "At least 1 number",
+          "special": "At least 1 special character"
+        }
       },
       "success": {
         "updated": "Password updated successfully."
@@ -417,6 +425,7 @@
         "currentIncorrect": "Current password is incorrect.",
         "sameAsCurrent": "The new password must be different from the current one.",
         "mismatch": "The new password and confirmation do not match.",
+        "weakPolicy": "The new password does not meet the security policy.",
         "unauthorized": "Your session expired. Please sign in again.",
         "generic": "Could not change password. Please try again."
       }
@@ -457,6 +466,14 @@
       "emailRequired": "Email is required",
       "emailInvalid": "Invalid email format",
       "passwordMin": "Password must be at least 8 characters",
+      "passwordWeak": "Password does not meet security criteria.",
+      "passwordChecklist": {
+        "minLength": "At least 8 characters",
+        "uppercase": "At least 1 uppercase letter",
+        "lowercase": "At least 1 lowercase letter",
+        "number": "At least 1 number",
+        "special": "At least 1 special character"
+      },
       "confirmRequired": "You must confirm your password",
       "passwordMismatch": "Passwords do not match"
     },
@@ -470,6 +487,7 @@
     "error": {
       "userExists": "User is already registered",
       "emailExists": "Email is already registered",
+      "weakPassword": "Password does not meet security policy",
       "invalidData": "Invalid data",
       "backendConnection": "Could not connect to backend",
       "server": "Server error. Please try again"

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -408,7 +408,15 @@
       },
       "validation": {
         "minLength": "La nueva contraseña debe tener al menos 8 caracteres.",
-        "mismatch": "La nueva contraseña y su repetición no coinciden."
+        "mismatch": "La nueva contraseña y su repetición no coinciden.",
+        "weakPolicy": "La nueva contraseña no cumple la política de seguridad.",
+        "checklist": {
+          "minLength": "Mínimo 8 caracteres",
+          "uppercase": "Al menos 1 mayúscula",
+          "lowercase": "Al menos 1 minúscula",
+          "number": "Al menos 1 número",
+          "special": "Al menos 1 carácter especial"
+        }
       },
       "success": {
         "updated": "Contraseña actualizada correctamente."
@@ -417,6 +425,7 @@
         "currentIncorrect": "La contraseña actual no es correcta.",
         "sameAsCurrent": "La nueva contraseña debe ser distinta a la actual.",
         "mismatch": "La nueva contraseña y su repetición no coinciden.",
+        "weakPolicy": "La nueva contraseña no cumple la política de seguridad.",
         "unauthorized": "Tu sesión expiró. Vuelve a iniciar sesión.",
         "generic": "No se pudo cambiar la contraseña. Intenta nuevamente."
       }
@@ -457,6 +466,14 @@
       "emailRequired": "El correo es obligatorio",
       "emailInvalid": "Formato de correo inválido",
       "passwordMin": "La contraseña debe tener mínimo 8 caracteres",
+      "passwordWeak": "La contraseña no cumple los criterios de seguridad.",
+      "passwordChecklist": {
+        "minLength": "Mínimo 8 caracteres",
+        "uppercase": "Al menos 1 mayúscula",
+        "lowercase": "Al menos 1 minúscula",
+        "number": "Al menos 1 número",
+        "special": "Al menos 1 carácter especial"
+      },
       "confirmRequired": "Debes confirmar tu contraseña",
       "passwordMismatch": "Las contraseñas no coinciden"
     },
@@ -470,6 +487,7 @@
     "error": {
       "userExists": "El usuario ya está registrado",
       "emailExists": "El correo ya está registrado",
+      "weakPassword": "La contraseña no cumple la política de seguridad",
       "invalidData": "Datos inválidos",
       "backendConnection": "No se pudo conectar con el backend",
       "server": "Error del servidor. Intenta nuevamente"

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -409,7 +409,15 @@
       },
       "validation": {
         "minLength": "A nova senha deve ter pelo menos 8 caracteres.",
-        "mismatch": "A nova senha e a confirmação não coincidem."
+        "mismatch": "A nova senha e a confirmação não coincidem.",
+        "weakPolicy": "A nova senha não atende à política de segurança.",
+        "checklist": {
+          "minLength": "Pelo menos 8 caracteres",
+          "uppercase": "Pelo menos 1 letra maiúscula",
+          "lowercase": "Pelo menos 1 letra minúscula",
+          "number": "Pelo menos 1 número",
+          "special": "Pelo menos 1 caractere especial"
+        }
       },
       "success": {
         "updated": "Senha atualizada com sucesso."
@@ -418,6 +426,7 @@
         "currentIncorrect": "A senha atual está incorreta.",
         "sameAsCurrent": "A nova senha deve ser diferente da senha atual.",
         "mismatch": "A nova senha e a confirmação não coincidem.",
+        "weakPolicy": "A nova senha não atende à política de segurança.",
         "unauthorized": "Sua sessão expirou. Faça login novamente.",
         "generic": "Não foi possível alterar a senha. Tente novamente."
       }
@@ -458,6 +467,14 @@
       "emailRequired": "O email é obrigatório",
       "emailInvalid": "Formato de email inválido",
       "passwordMin": "A senha deve ter pelo menos 8 caracteres",
+      "passwordWeak": "A senha não atende aos critérios de segurança.",
+      "passwordChecklist": {
+        "minLength": "Pelo menos 8 caracteres",
+        "uppercase": "Pelo menos 1 letra maiúscula",
+        "lowercase": "Pelo menos 1 letra minúscula",
+        "number": "Pelo menos 1 número",
+        "special": "Pelo menos 1 caractere especial"
+      },
       "confirmRequired": "Você deve confirmar sua senha",
       "passwordMismatch": "As senhas não coincidem"
     },
@@ -471,6 +488,7 @@
     "error": {
       "userExists": "O usuário já está registrado",
       "emailExists": "O email já está registrado",
+      "weakPassword": "A senha não atende à política de segurança",
       "invalidData": "Dados inválidos",
       "backendConnection": "Não foi possível conectar ao backend",
       "server": "Erro no servidor. Tente novamente"


### PR DESCRIPTION
# PR - HU-134: Contrasena segura en Registro con checklist visible

## Contexto

Esta historia implementa una politica de contrasena segura y feedback visible para el usuario durante el registro. Ademas, se extendio la misma politica al flujo de cambio de contrasena para mantener consistencia de seguridad en toda la aplicacion.

## Historia de Usuario

**Como** usuario en proceso de registro  
**Quiero** conocer y cumplir criterios de seguridad de contrasena antes de enviar  
**Para** crear cuentas mas seguras y evitar rechazos confusos

## Criterios implementados

- Politica minima de contrasena:
  - minimo 8 caracteres
  - al menos 1 mayuscula
  - al menos 1 minuscula
  - al menos 1 numero
  - al menos 1 caracter especial
- Checklist visible en tiempo real en frontend.
- Bloqueo de envio cuando no cumple.
- Validacion en backend (no se confia solo en frontend).
- Confirmacion de contrasena debe coincidir.
- Misma politica aplicada tambien en **Cambiar contrasena**.

## Cambios tecnicos

### Backend

Nuevos componentes de validacion:

- `backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicy.java`
- `backend/src/main/java/com/easyschedule/backend/shared/validation/PasswordPolicyValidator.java`

Aplicacion de politica:

- `backend/src/main/java/com/easyschedule/backend/auth/dto/request/SignupRequest.java`
- `backend/src/main/java/com/easyschedule/backend/auth/dto/RegistroRequest.java`
- `backend/src/main/java/com/easyschedule/backend/auth/dto/request/ChangePasswordRequest.java`

Detalle:

- Se estandariza longitud a `8..120` en DTOs de registro/cambio.
- Se valida complejidad con `@PasswordPolicy`.

### Frontend - Registro

Archivos:

- `frontend/src/app/features/registro/registro.ts`
- `frontend/src/app/features/registro/registro.html`
- `frontend/src/app/features/registro/registro.scss`

Detalle:

- Nuevo validador de politica en el control `password`.
- Checklist visible y reactivo (cumplido/no cumplido).
- Si el formulario es invalido, marca campos y evita submit.
- Manejo de error `400` por contrasena debil con mensaje especifico.

### Frontend - Perfil (Cambiar contrasena)

Archivos:

- `frontend/src/app/features/perfil/perfil.ts`
- `frontend/src/app/features/perfil/perfil.html`
- `frontend/src/app/features/perfil/perfil.scss`

Detalle:

- Se aplica la misma politica a `newPassword`.
- Checklist visible en modal de cambio de contrasena.
- Mensaje especifico de politica debil en UI y toast.

### i18n

Actualizado en 3 idiomas:

- `frontend/src/assets/i18n/es.json`
- `frontend/src/assets/i18n/en.json`
- `frontend/src/assets/i18n/pt.json`

Incluye:

- textos de checklist,
- error de politica debil,
- mensajes para registro y cambio de contrasena.

## Pruebas realizadas

### Frontend

```bash
npm test -- --watch=false --browsers=ChromeHeadless --include="src/app/features/registro/registro.spec.ts"
npm test -- --watch=false --browsers=ChromeHeadless --include="src/app/features/perfil/perfil.spec.ts"
```

Resultado: tests en verde.

### Backend

```bash
./gradlew test --tests "com.easyschedule.backend.auth.controllers.AuthControllerTest" --tests "com.easyschedule.backend.auth.integration.AuthRegistrationIntegrationTest" --tests "com.easyschedule.backend.estudiante.controller.EstudianteControllerTest"
```

Resultado: build y tests en verde.

## Casos QA sugeridos

- [ ] Registro con `abcd1234` -> bloqueado (sin mayuscula/especial).
- [ ] Registro con `Abcd1234!` -> permitido.
- [ ] Registro con confirmacion distinta -> bloqueado.
- [ ] Cambio de contrasena en Perfil con `nuevapassword123` -> bloqueado.
- [ ] Cambio de contrasena con `NuevaPassword123!` y confirmacion correcta -> permitido.
- [ ] Verificar que checklist refleja estado en tiempo real.

## Evidencia visual

<img width="462" height="507" alt="image" src="https://github.com/user-attachments/assets/969b40ef-f683-404c-b11e-dc7406bd0618" />

<img width="496" height="526" alt="image" src="https://github.com/user-attachments/assets/5b54a7f7-ae33-4b9c-bf41-4d88f63c3be4" />

## Impacto y riesgo

- **Impacto:** Medio (registro + cambio de contrasena).
- **Riesgo:** Bajo-medio, por restriccion adicional de seguridad.
- **Mitigacion:** feedback claro en frontend + mensajes backend coherentes.
