### PR TITLE
Hu 112

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/estudiante/controller/EstudianteController.java
+++ b/backend/src/main/java/com/easyschedule/backend/estudiante/controller/EstudianteController.java
@@ -1,6 +1,7 @@
 package com.easyschedule.backend.estudiante.controller;
 
 import com.easyschedule.backend.auth.dto.RegistroRequest;
+import com.easyschedule.backend.estudiante.dto.AvanceGraduacionExport;
 import com.easyschedule.backend.estudiante.dto.EstudianteResponse;
 import com.easyschedule.backend.estudiante.dto.EstudianteUpdateRequest;
 import com.easyschedule.backend.estudiante.dto.PerfilUpdateRequest;
@@ -22,9 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.RequestParam;
 import com.easyschedule.backend.estudiante.service.EstudianteMallaExportService;
-import com.easyschedule.backend.shared.exception.ResourceNotFoundException;
 
 import java.security.Principal;
 
@@ -104,7 +103,16 @@ public class EstudianteController {
         return estudianteService.updateProfile(username, request);
     }
 
+    @GetMapping("/me/avance-graduacion/export")
+    public ResponseEntity<byte[]> exportarAvanceGraduacion(Principal principal) {
+        Long userId = getAuthenticatedUserId(principal);
+        AvanceGraduacionExport export = exportService.exportarAvanceGraduacion(userId, "pdf");
 
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + export.filename() + "\"")
+            .contentType(MediaType.parseMediaType(export.contentType()))
+            .body(export.contenido());
+    }
 
     private void validateProfileOwnership(String username, Long userId) {
         if (userId == null) {

--- a/backend/src/main/java/com/easyschedule/backend/estudiante/dto/AvanceGraduacionExport.java
+++ b/backend/src/main/java/com/easyschedule/backend/estudiante/dto/AvanceGraduacionExport.java
@@ -1,0 +1,7 @@
+package com.easyschedule.backend.estudiante.dto;
+
+public record AvanceGraduacionExport(
+    byte[] contenido,
+    String contentType,
+    String filename
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/estudiante/service/EstudianteMallaExportService.java
+++ b/backend/src/main/java/com/easyschedule/backend/estudiante/service/EstudianteMallaExportService.java
@@ -1,65 +1,280 @@
 package com.easyschedule.backend.estudiante.service;
 
+import com.easyschedule.backend.academico.carrera.model.Carrera;
+import com.easyschedule.backend.academico.carrera.repository.CarreraRepository;
 import com.easyschedule.backend.academico.malla.dto.MallaMateriaResponse;
 import com.easyschedule.backend.academico.malla.service.MallaService;
+import com.easyschedule.backend.academico.universidad.model.Universidad;
+import com.easyschedule.backend.academico.universidad.repository.UniversidadRepository;
+import com.easyschedule.backend.estudiante.dto.AvanceGraduacionExport;
 import com.easyschedule.backend.estudiante.model.Estudiante;
 import com.easyschedule.backend.estudiante.repository.EstudianteRepository;
 import com.easyschedule.backend.shared.exception.ResourceNotFoundException;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
+import java.io.ByteArrayOutputStream;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class EstudianteMallaExportService {
 
     private final EstudianteRepository estudianteRepository;
     private final MallaService mallaService;
+    private final UniversidadRepository universidadRepository;
+    private final CarreraRepository carreraRepository;
 
     public EstudianteMallaExportService(
             EstudianteRepository estudianteRepository,
-            MallaService mallaService) {
+            MallaService mallaService,
+            UniversidadRepository universidadRepository,
+            CarreraRepository carreraRepository) {
         this.estudianteRepository = estudianteRepository;
         this.mallaService = mallaService;
+        this.universidadRepository = universidadRepository;
+        this.carreraRepository = carreraRepository;
     }
 
-    public byte[] exportarMalla(Long estudianteId, String formato) {
+    public AvanceGraduacionExport exportarAvanceGraduacion(Long estudianteId, String formato) {
+        String formatoNormalizado = formato == null ? "pdf" : formato.trim().toLowerCase(Locale.ROOT);
+        if (!"pdf".equals(formatoNormalizado)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato de exportacion no soportado");
+        }
+
         Estudiante estudiante = estudianteRepository.findById(estudianteId)
                 .orElseThrow(() -> new ResourceNotFoundException("Estudiante no encontrado con id: " + estudianteId));
 
-        if (estudiante.getMalla() == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No existe malla disponible para exportar");
+        validarDatosSuficientes(estudiante);
+
+        Universidad universidad = universidadRepository.findByIdAndActiveTrue(estudiante.getUniversidadId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "No existen datos suficientes para generar el reporte"));
+        Carrera carrera = carreraRepository.findByIdAndActiveTrue(estudiante.getCarreraId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "No existen datos suficientes para generar el reporte"));
+
+        List<MallaMateriaResponse> materias = mallaService.findMateriasByMalla(estudiante.getMalla().getId(), estudianteId);
+        if (materias.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "No existen materias suficientes para generar el reporte");
         }
 
-        Long mallaId = estudiante.getMalla().getId();
-
-        // 🔥 ahora ya incluye estado
-        List<MallaMateriaResponse> materias = mallaService.findMateriasByMalla(mallaId, estudianteId);
-
-        StringBuilder csv = new StringBuilder();
-        csv.append("Semestre,Codigo,Materia,Estado\n");
-
-        for (MallaMateriaResponse materia : materias) {
-            csv.append(materia.semestreSugerido() != null ? materia.semestreSugerido() : "")
-               .append(",")
-               .append(escapeCsv(materia.codigoMateria()))
-               .append(",")
-               .append(escapeCsv(materia.nombreMateria()))
-               .append(",")
-               .append(materia.estado() != null ? materia.estado() : "PENDIENTE")
-               .append("\n");
-        }
-
-        return csv.toString().getBytes(StandardCharsets.UTF_8);
+        byte[] pdf = generarPdf(estudiante, universidad, carrera, materias);
+        return new AvanceGraduacionExport(pdf, "application/pdf", "avance_graduacion.pdf");
     }
 
-    private String escapeCsv(String value) {
-        if (value == null) return "";
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
-            return "\"" + value.replace("\"", "\"\"") + "\"";
+    private void validarDatosSuficientes(Estudiante estudiante) {
+        if (estudiante.getMalla() == null || estudiante.getUniversidadId() == null || estudiante.getCarreraId() == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "No existen datos suficientes para generar el reporte");
         }
-        return value;
     }
+
+    private byte[] generarPdf(
+        Estudiante estudiante,
+        Universidad universidad,
+        Carrera carrera,
+        List<MallaMateriaResponse> materias
+    ) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4, 36, 36, 42, 42);
+            PdfWriter.getInstance(document, outputStream);
+            document.open();
+
+            ReporteResumen resumen = calcularResumen(materias);
+            agregarTitulo(document);
+            agregarDatosGenerales(document, estudiante, universidad, carrera);
+            agregarResumen(document, resumen);
+            agregarMateriasPorSemestre(document, materias);
+            agregarMateriasFaltantes(document, materias);
+
+            document.close();
+            return outputStream.toByteArray();
+        } catch (DocumentException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "No se pudo generar el reporte de avance");
+        } catch (java.io.IOException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "No se pudo preparar el reporte de avance");
+        }
+    }
+
+    private void agregarTitulo(Document document) throws DocumentException {
+        Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18, new Color(32, 44, 64));
+        Paragraph title = new Paragraph("Reporte de avance de graduacion", titleFont);
+        title.setAlignment(Element.ALIGN_CENTER);
+        title.setSpacingAfter(14);
+        document.add(title);
+    }
+
+    private void agregarDatosGenerales(Document document, Estudiante estudiante, Universidad universidad, Carrera carrera)
+        throws DocumentException {
+        Font sectionFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12, new Color(32, 44, 64));
+        document.add(new Paragraph("Datos generales", sectionFont));
+
+        PdfPTable table = new PdfPTable(new float[] { 1.1f, 2.2f });
+        table.setWidthPercentage(100);
+        table.setSpacingBefore(6);
+        table.setSpacingAfter(12);
+
+        agregarFilaDato(table, "Estudiante", nombreCompleto(estudiante));
+        agregarFilaDato(table, "Usuario", estudiante.getUsername());
+        agregarFilaDato(table, "Correo", estudiante.getCorreo());
+        agregarFilaDato(table, "Universidad", universidad.getNombre());
+        agregarFilaDato(table, "Carrera", carrera.getNombre());
+        agregarFilaDato(table, "Malla", estudiante.getMalla().getNombre() + " - " + estudiante.getMalla().getVersion());
+        agregarFilaDato(table, "Fecha de emision", OffsetDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+
+        document.add(table);
+    }
+
+    private void agregarResumen(Document document, ReporteResumen resumen) throws DocumentException {
+        Font sectionFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12, new Color(32, 44, 64));
+        document.add(new Paragraph("Resumen de avance", sectionFont));
+
+        PdfPTable table = new PdfPTable(4);
+        table.setWidthPercentage(100);
+        table.setSpacingBefore(6);
+        table.setSpacingAfter(12);
+        agregarHeader(table, "Avance total");
+        agregarHeader(table, "Aprobadas");
+        agregarHeader(table, "En curso");
+        agregarHeader(table, "Pendientes");
+        agregarCelda(table, String.format(Locale.ROOT, "%.2f%%", resumen.porcentajeAvance()));
+        agregarCelda(table, String.valueOf(resumen.aprobadas()));
+        agregarCelda(table, String.valueOf(resumen.cursando()));
+        agregarCelda(table, String.valueOf(resumen.pendientes()));
+        document.add(table);
+    }
+
+    private void agregarMateriasPorSemestre(Document document, List<MallaMateriaResponse> materias) throws DocumentException {
+        Font sectionFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12, new Color(32, 44, 64));
+        document.add(new Paragraph("Malla curricular por semestre", sectionFont));
+
+        Map<Short, List<MallaMateriaResponse>> porSemestre = materias.stream()
+            .sorted(Comparator.comparing(MallaMateriaResponse::semestreSugerido, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(MallaMateriaResponse::codigoMateria, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+            .collect(Collectors.groupingBy(
+                materia -> materia.semestreSugerido() == null ? 0 : materia.semestreSugerido(),
+                java.util.LinkedHashMap::new,
+                Collectors.toList()
+            ));
+
+        for (Map.Entry<Short, List<MallaMateriaResponse>> entry : porSemestre.entrySet()) {
+            Paragraph semester = new Paragraph(entry.getKey() == 0 ? "Sin semestre" : "Semestre " + entry.getKey(),
+                FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10));
+            semester.setSpacingBefore(8);
+            semester.setSpacingAfter(4);
+            document.add(semester);
+
+            PdfPTable table = new PdfPTable(new float[] { 1f, 3f, 1.2f });
+            table.setWidthPercentage(100);
+            agregarHeader(table, "Codigo");
+            agregarHeader(table, "Materia");
+            agregarHeader(table, "Estado");
+
+            for (MallaMateriaResponse materia : entry.getValue()) {
+                agregarCelda(table, valor(materia.codigoMateria()));
+                agregarCelda(table, valor(materia.nombreMateria()));
+                agregarCelda(table, etiquetaEstado(materia.estado()));
+            }
+
+            document.add(table);
+        }
+    }
+
+    private void agregarMateriasFaltantes(Document document, List<MallaMateriaResponse> materias) throws DocumentException {
+        List<MallaMateriaResponse> faltantes = materias.stream()
+            .filter(materia -> !"aprobada".equals(normalizarEstado(materia.estado())))
+            .toList();
+
+        Font sectionFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12, new Color(32, 44, 64));
+        Paragraph title = new Paragraph("Materias faltantes para completar la carrera", sectionFont);
+        title.setSpacingBefore(12);
+        document.add(title);
+
+        if (faltantes.isEmpty()) {
+            document.add(new Paragraph("Todas las materias de la malla estan aprobadas."));
+            return;
+        }
+
+        PdfPTable table = new PdfPTable(new float[] { 1f, 3f, 1.2f });
+        table.setWidthPercentage(100);
+        table.setSpacingBefore(6);
+        agregarHeader(table, "Codigo");
+        agregarHeader(table, "Materia");
+        agregarHeader(table, "Estado");
+
+        for (MallaMateriaResponse materia : faltantes) {
+            agregarCelda(table, valor(materia.codigoMateria()));
+            agregarCelda(table, valor(materia.nombreMateria()));
+            agregarCelda(table, etiquetaEstado(materia.estado()));
+        }
+
+        document.add(table);
+    }
+
+    private ReporteResumen calcularResumen(List<MallaMateriaResponse> materias) {
+        long aprobadas = materias.stream().filter(materia -> "aprobada".equals(normalizarEstado(materia.estado()))).count();
+        long cursando = materias.stream().filter(materia -> "cursando".equals(normalizarEstado(materia.estado()))).count();
+        long pendientes = materias.size() - aprobadas - cursando;
+        double porcentaje = materias.isEmpty() ? 0.0 : (aprobadas * 100.0) / materias.size();
+        return new ReporteResumen(materias.size(), aprobadas, cursando, pendientes, porcentaje);
+    }
+
+    private void agregarFilaDato(PdfPTable table, String label, String value) {
+        agregarHeader(table, label);
+        agregarCelda(table, valor(value));
+    }
+
+    private void agregarHeader(PdfPTable table, String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(value, FontFactory.getFont(FontFactory.HELVETICA_BOLD, 9, Color.WHITE)));
+        cell.setBackgroundColor(new Color(63, 99, 131));
+        cell.setPadding(6);
+        table.addCell(cell);
+    }
+
+    private void agregarCelda(PdfPTable table, String value) {
+        PdfPCell cell = new PdfPCell(new Phrase(value, FontFactory.getFont(FontFactory.HELVETICA, 9)));
+        cell.setPadding(6);
+        table.addCell(cell);
+    }
+
+    private String nombreCompleto(Estudiante estudiante) {
+        String nombre = valor(estudiante.getNombre());
+        String apellido = valor(estudiante.getApellido());
+        String completo = (nombre + " " + apellido).trim();
+        return completo.isBlank() ? valor(estudiante.getUsername()) : completo;
+    }
+
+    private String etiquetaEstado(String estado) {
+        return switch (normalizarEstado(estado)) {
+            case "aprobada" -> "Aprobada";
+            case "cursando" -> "En curso";
+            default -> "Pendiente";
+        };
+    }
+
+    private String normalizarEstado(String estado) {
+        return estado == null ? "pendiente" : estado.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String valor(String value) {
+        return value == null || value.isBlank() ? "-" : value;
+    }
+
+    private record ReporteResumen(long total, long aprobadas, long cursando, long pendientes, double porcentajeAvance) {}
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
@@ -18,7 +18,8 @@ public class FeatureToggleInterceptor implements HandlerInterceptor {
         "/api/academico/carreras",
         "/api/academico/mallas",
         "/api/academico/seleccion",
-        "/api/academico/estados-materia"
+        "/api/academico/estados-materia",
+        "/api/estudiantes/me/avance-graduacion"
     );
 
     private static final List<String> OFERTAS_IMPORT_PATH_PREFIXES = List.of(

--- a/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/estudiante/controller/EstudianteControllerTest.java
@@ -5,11 +5,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import com.easyschedule.backend.estudiante.dto.AvanceGraduacionExport;
 import com.easyschedule.backend.estudiante.service.EstudianteMallaExportService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,6 +108,25 @@ class EstudianteControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(invalidBody))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void exportarAvanceGraduacionReturnsDownloadablePdfForAuthenticatedUser() throws Exception {
+        when(exportService.exportarAvanceGraduacion(1L, "pdf"))
+            .thenReturn(new AvanceGraduacionExport("%PDF-test".getBytes(), "application/pdf", "avance_graduacion.pdf"));
+
+        mockMvc.perform(get("/api/estudiantes/me/avance-graduacion/export").principal(() -> "1"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", "application/pdf"))
+            .andExpect(header().string("Content-Disposition", "attachment; filename=\"avance_graduacion.pdf\""));
+
+        verify(exportService).exportarAvanceGraduacion(1L, "pdf");
+    }
+
+    @Test
+    void exportarAvanceGraduacionReturnsUnauthorizedWhenPrincipalMissing() throws Exception {
+        mockMvc.perform(get("/api/estudiantes/me/avance-graduacion/export"))
+            .andExpect(status().isUnauthorized());
     }
 
     private EstudianteResponse mockResponse(String username) {

--- a/backend/src/test/java/com/easyschedule/backend/estudiante/service/EstudianteMallaExportServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/estudiante/service/EstudianteMallaExportServiceTest.java
@@ -1,0 +1,116 @@
+package com.easyschedule.backend.estudiante.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.easyschedule.backend.academico.carrera.model.Carrera;
+import com.easyschedule.backend.academico.carrera.repository.CarreraRepository;
+import com.easyschedule.backend.academico.malla.dto.MallaMateriaResponse;
+import com.easyschedule.backend.academico.malla.model.Malla;
+import com.easyschedule.backend.academico.malla.service.MallaService;
+import com.easyschedule.backend.academico.universidad.model.Universidad;
+import com.easyschedule.backend.academico.universidad.repository.UniversidadRepository;
+import com.easyschedule.backend.estudiante.model.Estudiante;
+import com.easyschedule.backend.estudiante.repository.EstudianteRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class EstudianteMallaExportServiceTest {
+
+    @Mock
+    private EstudianteRepository estudianteRepository;
+
+    @Mock
+    private MallaService mallaService;
+
+    @Mock
+    private UniversidadRepository universidadRepository;
+
+    @Mock
+    private CarreraRepository carreraRepository;
+
+    @InjectMocks
+    private EstudianteMallaExportService exportService;
+
+    @Test
+    void exportarAvanceGraduacionGeneratesPdfWithCurrentSubjectStates() {
+        Estudiante estudiante = buildEstudiante();
+        Universidad universidad = mock(Universidad.class);
+        Carrera carrera = mock(Carrera.class);
+
+        when(universidad.getNombre()).thenReturn("UCB");
+        when(carrera.getNombre()).thenReturn("Ingenieria de Sistemas");
+        when(estudianteRepository.findById(1L)).thenReturn(Optional.of(estudiante));
+        when(universidadRepository.findByIdAndActiveTrue(10L)).thenReturn(Optional.of(universidad));
+        when(carreraRepository.findByIdAndActiveTrue(20L)).thenReturn(Optional.of(carrera));
+        when(mallaService.findMateriasByMalla(30L, 1L)).thenReturn(List.of(
+            new MallaMateriaResponse(100L, 200L, "SIS101", "Programacion I", (short) 1, "aprobada", List.of()),
+            new MallaMateriaResponse(101L, 201L, "SIS102", "Programacion II", (short) 2, "cursando", List.of(100L)),
+            new MallaMateriaResponse(102L, 202L, "SIS103", "Bases de Datos", (short) 3, null, List.of(101L))
+        ));
+
+        var export = exportService.exportarAvanceGraduacion(1L, "pdf");
+
+        assertEquals("application/pdf", export.contentType());
+        assertEquals("avance_graduacion.pdf", export.filename());
+        assertTrue(new String(export.contenido(), 0, 4, StandardCharsets.ISO_8859_1).startsWith("%PDF"));
+    }
+
+    @Test
+    void exportarAvanceGraduacionThrowsClearErrorWhenDataIsInsufficient() {
+        Estudiante estudiante = new Estudiante();
+        estudiante.setId(1L);
+        estudiante.setUniversidadId(10L);
+        estudiante.setCarreraId(20L);
+
+        when(estudianteRepository.findById(1L)).thenReturn(Optional.of(estudiante));
+
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> exportService.exportarAvanceGraduacion(1L, "pdf")
+        );
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, ex.getStatusCode());
+        assertEquals("No existen datos suficientes para generar el reporte", ex.getReason());
+    }
+
+    @Test
+    void exportarAvanceGraduacionRejectsUnsupportedFormats() {
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> exportService.exportarAvanceGraduacion(1L, "xlsx")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+    }
+
+    private Estudiante buildEstudiante() {
+        Malla malla = new Malla();
+        malla.setId(30L);
+        malla.setNombre("Malla 2024");
+        malla.setVersion("2024");
+
+        Estudiante estudiante = new Estudiante();
+        estudiante.setId(1L);
+        estudiante.setUsername("diego");
+        estudiante.setNombre("Diego");
+        estudiante.setApellido("Suarez");
+        estudiante.setCorreo("diego@mail.com");
+        estudiante.setUniversidadId(10L);
+        estudiante.setCarreraId(20L);
+        estudiante.setMalla(malla);
+        return estudiante;
+    }
+}

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -47,6 +47,14 @@
         <button type="button" class="malla-button malla-button--outline" *ngIf="ofertasImportEnabled" [disabled]="materias.length === 0" (click)="onImportarOfertasClick()">
         {{ 'malla.actions.importOffers' | translate }}
         </button>   
+        <button
+          type="button"
+          class="malla-button malla-button--outline"
+          [disabled]="exportingAvance || loadingMaterias"
+          (click)="onExportarAvanceClick()"
+        >
+          {{ exportingAvance ? ('malla.export.loading' | translate) : ('malla.export.button' | translate) }}
+        </button>
         <button type="button" class="malla-button malla-button--outline" (click)="onCambiarMallaClick()">
           {{ 'malla.actions.changeMalla' | translate }}
         </button>

--- a/frontend/src/app/features/malla/malla.spec.ts
+++ b/frontend/src/app/features/malla/malla.spec.ts
@@ -1,5 +1,11 @@
 import { HttpClient } from '@angular/common/http';
+import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject, of, throwError } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { Malla } from './malla';
 import { CarreraService } from '../../services/academico/carrera.service';
@@ -13,6 +19,8 @@ import { AuthSessionService } from '../../core/services/auth-session.service';
 import { PerfilService } from '../perfil/perfil.service';
 import { ToastService } from '../../core/services/toast.service';
 import { TourHintsService } from '../../services/tour-hints.service';
+import { SeleccionTemporalService } from '../../services/academico/seleccion-temporal.service';
+import { EstadoMateriaService } from '../../services/academico/estado-materia.service';
 
 describe('Malla component logic', () => {
   let component: Malla;
@@ -30,6 +38,7 @@ describe('Malla component logic', () => {
   let perfilServiceSpy: jasmine.SpyObj<PerfilService>;
   let toastServiceSpy: jasmine.SpyObj<ToastService>;
   let tourHintsServiceSpy: jasmine.SpyObj<TourHintsService>;
+  let seleccionTemporalServiceSpy: jasmine.SpyObj<SeleccionTemporalService>;
   let routerSpy: jasmine.SpyObj<any>;
   let activatedRouteStub: any;
 
@@ -42,7 +51,12 @@ describe('Malla component logic', () => {
 
     universidadServiceSpy = jasmine.createSpyObj<UniversidadService>('UniversidadService', ['getUniversidadesActivas']);
     carreraServiceSpy = jasmine.createSpyObj<CarreraService>('CarreraService', ['getCarrerasActivasPorUniversidad']);
-    mallaCatalogoServiceSpy = jasmine.createSpyObj<MallaCatalogoService>('MallaCatalogoService', ['getMallasActivasPorCarrera', 'getMateriasPorMalla']);
+    mallaCatalogoServiceSpy = jasmine.createSpyObj<MallaCatalogoService>('MallaCatalogoService', [
+      'getMallasActivasPorCarrera',
+      'getMateriasPorMalla',
+      'exportarAvanceGraduacion',
+      'getDetallesMateria',
+    ]);
     seleccionAcademicaServiceSpy = jasmine.createSpyObj<SeleccionAcademicaService>('SeleccionAcademicaService', ['getSeleccionActual', 'guardarSeleccion']);
     estadoMateriaServiceSpy = jasmine.createSpyObj('EstadoMateriaService', ['getEstadosMateria', 'guardarEstado']);
     tomaSeleccionServiceSpy = jasmine.createSpyObj<TomaSeleccionService>('TomaSeleccionService', ['agregarMateria']);
@@ -50,8 +64,9 @@ describe('Malla component logic', () => {
     translateServiceSpy = jasmine.createSpyObj<TranslateService>('TranslateService', ['instant']);
     translateServiceSpy.instant.and.callFake((key: string) => key);
     httpClientSpy = jasmine.createSpyObj<HttpClient>('HttpClient', ['get', 'post']);
-    authSessionServiceSpy = jasmine.createSpyObj<AuthSessionService>('AuthSessionService', ['getCurrentUsername']);
+    authSessionServiceSpy = jasmine.createSpyObj<AuthSessionService>('AuthSessionService', ['getCurrentUsername', 'isLoggedIn']);
     authSessionServiceSpy.getCurrentUsername.and.returnValue('testuser');
+    authSessionServiceSpy.isLoggedIn.and.returnValue(true);
     perfilServiceSpy = jasmine.createSpyObj<PerfilService>('PerfilService', ['getPerfilByUsername', 'completeTour']);
     perfilServiceSpy.getPerfilByUsername.and.returnValue(of({ tourCompleted: true } as any));
     perfilServiceSpy.completeTour.and.returnValue(of({}) as any);
@@ -60,7 +75,14 @@ describe('Malla component logic', () => {
       'openTomaMateriasPopover',
       'closeTomaMateriasPopover',
     ]);
+    seleccionTemporalServiceSpy = jasmine.createSpyObj<SeleccionTemporalService>('SeleccionTemporalService', [
+      'listarSelecciones',
+      'agregarSeleccion',
+      'limpiarSelecciones',
+    ]);
+    seleccionTemporalServiceSpy.listarSelecciones.and.returnValue(of([]));
     routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl']);
+    Object.defineProperty(routerSpy, 'events', { value: of([]) });
     activatedRouteStub = { snapshot: { queryParams: {} } };
 
     component = new (Malla as any)(
@@ -79,6 +101,7 @@ describe('Malla component logic', () => {
       authSessionServiceSpy,
       perfilServiceSpy,
       tourHintsServiceSpy,
+      seleccionTemporalServiceSpy,
     );
   });
 
@@ -237,4 +260,136 @@ describe('Malla component logic', () => {
     expect((component as any).loadMateriasError).toBeTrue();
     expect((component as any).loadingMaterias).toBeFalse();
   });
+
+  it('calls graduation progress export endpoint when export button action runs', async () => {
+    const response = buildBlobResponse('avance_graduacion.pdf');
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(of(response));
+    spyOn(component as any, 'downloadBlob');
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(mallaCatalogoServiceSpy.exportarAvanceGraduacion).toHaveBeenCalled();
+  });
+
+  it('shows loading state during graduation progress export', () => {
+    const exportSubject = new Subject<HttpResponse<Blob>>();
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(exportSubject.asObservable());
+    spyOn(component as any, 'downloadBlob');
+
+    void (component as any).onExportarAvanceClick();
+
+    expect((component as any).exportingAvance).toBeTrue();
+
+    exportSubject.next(buildBlobResponse('avance_graduacion.pdf'));
+    exportSubject.complete();
+  });
+
+  it('downloads the generated report when export succeeds', async () => {
+    const response = buildBlobResponse('avance_graduacion.pdf');
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(of(response));
+    const downloadSpy = spyOn(component as any, 'downloadBlob');
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(downloadSpy).toHaveBeenCalledWith(response.body, 'avance_graduacion.pdf');
+    expect(toastServiceSpy.success).toHaveBeenCalledWith('malla.export.success');
+  });
+
+  it('uses filename received from backend when export succeeds', async () => {
+    const response = buildBlobResponse('mi_avance.pdf');
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(of(response));
+    const downloadSpy = spyOn(component as any, 'downloadBlob');
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(downloadSpy).toHaveBeenCalledWith(response.body, 'mi_avance.pdf');
+  });
+
+  it('shows insufficient data error when backend rejects export data', async () => {
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 422 })),
+    );
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(toastServiceSpy.error).toHaveBeenCalledWith('malla.export.insufficientData');
+  });
+
+  it('shows connection error when export request fails by network', async () => {
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(
+      throwError(() => new HttpErrorResponse({ status: 0 })),
+    );
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(toastServiceSpy.error).toHaveBeenCalledWith('malla.export.connectionError');
+  });
+
+  it('ignores duplicate export clicks while request is in progress', () => {
+    const exportSubject = new Subject<HttpResponse<Blob>>();
+    mallaCatalogoServiceSpy.exportarAvanceGraduacion.and.returnValue(exportSubject.asObservable());
+    spyOn(component as any, 'downloadBlob');
+
+    void (component as any).onExportarAvanceClick();
+    void (component as any).onExportarAvanceClick();
+
+    expect(mallaCatalogoServiceSpy.exportarAvanceGraduacion).toHaveBeenCalledTimes(1);
+    exportSubject.next(buildBlobResponse('avance_graduacion.pdf'));
+    exportSubject.complete();
+  });
+
+  it('does not export when user is not authenticated', async () => {
+    authSessionServiceSpy.isLoggedIn.and.returnValue(false);
+
+    await (component as any).onExportarAvanceClick();
+
+    expect(mallaCatalogoServiceSpy.exportarAvanceGraduacion).not.toHaveBeenCalled();
+    expect(toastServiceSpy.error).toHaveBeenCalledWith('malla.export.notAuthenticated');
+  });
+
+  it('renders graduation progress export button', async () => {
+    universidadServiceSpy.getUniversidadesActivas.and.returnValue(of([]));
+    seleccionAcademicaServiceSpy.getSeleccionActual.and.returnValue(throwError(() => new Error('empty')));
+    mallaCatalogoServiceSpy.getMateriasPorMalla.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [Malla, TranslateModule.forRoot()],
+      providers: [
+        { provide: FeatureToggleService, useValue: featureServiceMock },
+        { provide: UniversidadService, useValue: universidadServiceSpy },
+        { provide: CarreraService, useValue: carreraServiceSpy },
+        { provide: MallaCatalogoService, useValue: mallaCatalogoServiceSpy },
+        { provide: SeleccionAcademicaService, useValue: seleccionAcademicaServiceSpy },
+        { provide: EstadoMateriaService, useValue: estadoMateriaServiceSpy },
+        { provide: TomaSeleccionService, useValue: tomaSeleccionServiceSpy },
+        { provide: HttpClient, useValue: httpClientSpy },
+        { provide: ToastService, useValue: toastServiceSpy },
+        { provide: AuthSessionService, useValue: authSessionServiceSpy },
+        { provide: PerfilService, useValue: perfilServiceSpy },
+        { provide: TourHintsService, useValue: tourHintsServiceSpy },
+        { provide: SeleccionTemporalService, useValue: seleccionTemporalServiceSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+        { provide: Router, useValue: routerSpy },
+      ],
+    }).compileComponents();
+
+    const fixture: ComponentFixture<Malla> = TestBed.createComponent(Malla);
+    (fixture.componentInstance as any).mallaEnabled = true;
+    (fixture.componentInstance as any).step = 'resumen';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const buttons = fixture.debugElement.queryAll(By.css('.malla-page__actions button'));
+    const hasExportButton = buttons.some((button) => button.nativeElement.textContent.includes('malla.export.button'));
+
+    expect(hasExportButton).toBeTrue();
+  });
+
+  function buildBlobResponse(filename: string): HttpResponse<Blob> {
+    return new HttpResponse({
+      body: new Blob(['pdf'], { type: 'application/pdf' }),
+      headers: new HttpHeaders({ 'content-disposition': `attachment; filename="${filename}"` }),
+    });
+  }
 });

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -1,7 +1,7 @@
 import { NgFor, NgIf, NgClass } from '@angular/common';
 import { Component, OnDestroy, OnInit, HostListener, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { filter, firstValueFrom, Subscription } from 'rxjs';
@@ -70,6 +70,7 @@ export class Malla implements OnInit, OnDestroy {
   protected semestreActual = 1;
   protected loadingMaterias = false;
   protected loadMateriasError = false;
+  protected exportingAvance = false;
 
   protected loadingUniversidades = true;
   protected loadingCarreras = false;
@@ -614,6 +615,35 @@ Reglas obligatorias:
     this.showImportarOfertasModal = true;
   }
 
+  protected async onExportarAvanceClick(): Promise<void> {
+    if (this.exportingAvance) {
+      return;
+    }
+
+    if (!this.authSessionService.isLoggedIn()) {
+      this.toastService.error('malla.export.notAuthenticated');
+      return;
+    }
+
+    this.exportingAvance = true;
+
+    try {
+      const response = await firstValueFrom(this.mallaCatalogoService.exportarAvanceGraduacion());
+      const blob = response.body;
+
+      if (!blob) {
+        throw new Error('empty-response');
+      }
+
+      this.downloadBlob(blob, this.getExportFilename(response));
+      this.toastService.success('malla.export.success');
+    } catch (error) {
+      this.toastService.error(this.getExportErrorKey(error));
+    } finally {
+      this.exportingAvance = false;
+    }
+  }
+
   protected closeImportarOfertasModal(): void {
     this.showImportarOfertasModal = false;
   }
@@ -650,6 +680,53 @@ Reglas obligatorias:
     } finally {
       this.loadingUniversidades = false;
     }
+  }
+
+  private getExportFilename(response: HttpResponse<Blob>): string {
+    const contentDisposition = response.headers.get('content-disposition') ?? '';
+    const utf8Match = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+    const asciiMatch = /filename="?([^";]+)"?/i.exec(contentDisposition);
+    const encodedFilename = utf8Match?.[1] ?? asciiMatch?.[1];
+
+    if (!encodedFilename) {
+      return 'avance_graduacion.pdf';
+    }
+
+    try {
+      return decodeURIComponent(encodedFilename);
+    } catch {
+      return encodedFilename;
+    }
+  }
+
+  private getExportErrorKey(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      if (error.status === 401 || error.status === 403) {
+        return 'malla.export.notAuthenticated';
+      }
+
+      if (error.status === 422 || error.status === 404 || error.status === 400) {
+        return 'malla.export.insufficientData';
+      }
+
+      if (error.status === 0) {
+        return 'malla.export.connectionError';
+      }
+    }
+
+    return 'malla.export.downloadError';
+  }
+
+  private downloadBlob(blob: Blob, filename: string): void {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
   }
 
   private async loadSeleccionActual(): Promise<void> {

--- a/frontend/src/app/features/toma-de-materias/toma-de-materias.spec.ts
+++ b/frontend/src/app/features/toma-de-materias/toma-de-materias.spec.ts
@@ -3,16 +3,16 @@ import { of, throwError } from 'rxjs';
 import { TomaDeMaterias } from './toma-de-materias';
 import { HorarioActualService, HorarioActualResponse } from '../../services/academico/horario-actual.service';
 import { ApiService } from '../../services/api.service';
-import { TomaSeleccionService } from '../../services/academico/toma-seleccion.service';
 import { AuthSessionService } from '../../core/services/auth-session.service';
 import { PerfilService } from '../perfil/perfil.service';
 import { TranslateService } from '@ngx-translate/core';
+import { SeleccionTemporalService } from '../../services/academico/seleccion-temporal.service';
 
 describe('TomaDeMaterias', () => {
   let component: TomaDeMaterias;
   let horarioActualServiceSpy: jasmine.SpyObj<HorarioActualService>;
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
-  let tomaSeleccionServiceSpy: jasmine.SpyObj<TomaSeleccionService>;
+  let seleccionTemporalServiceSpy: jasmine.SpyObj<SeleccionTemporalService>;
   let authSessionServiceSpy: jasmine.SpyObj<AuthSessionService>;
   let perfilServiceSpy: jasmine.SpyObj<PerfilService>;
   let translateServiceSpy: jasmine.SpyObj<TranslateService>;
@@ -26,7 +26,11 @@ describe('TomaDeMaterias', () => {
       'exportHorarioActualImage',
     ]);
     apiServiceSpy = jasmine.createSpyObj('ApiService', ['post', 'get', 'put', 'delete']);
-    tomaSeleccionServiceSpy = jasmine.createSpyObj('TomaSeleccionService', ['removerMateria', 'limpiar', 'agregarMateria']);
+    seleccionTemporalServiceSpy = jasmine.createSpyObj<SeleccionTemporalService>('SeleccionTemporalService', [
+      'listarSelecciones',
+      'removerSeleccion',
+      'limpiarSelecciones',
+    ]);
     authSessionServiceSpy = jasmine.createSpyObj<AuthSessionService>('AuthSessionService', ['getCurrentUsername']);
     perfilServiceSpy = jasmine.createSpyObj<PerfilService>('PerfilService', ['getPerfilByUsername']);
     translateServiceSpy = jasmine.createSpyObj<TranslateService>('TranslateService', ['instant']);
@@ -53,17 +57,16 @@ describe('TomaDeMaterias', () => {
     horarioActualServiceSpy.getHorarioActual.and.returnValue(of(mockResponse));
     authSessionServiceSpy.getCurrentUsername.and.returnValue(null);
     mallaCatalogoServiceSpy.getMateriasPorMalla.and.returnValue(of([]));
-
-    Object.defineProperty(tomaSeleccionServiceSpy, 'seleccion$', { value: of([]) });
+    seleccionTemporalServiceSpy.listarSelecciones.and.returnValue(of([]));
 
     component = new TomaDeMaterias(
       horarioActualServiceSpy,
       apiServiceSpy,
-      tomaSeleccionServiceSpy,
       authSessionServiceSpy,
       perfilServiceSpy,
       translateServiceSpy,
       mallaCatalogoServiceSpy,
+      seleccionTemporalServiceSpy,
     );
   });
 

--- a/frontend/src/app/features/toma-de-materias/toma-de-materias.ts
+++ b/frontend/src/app/features/toma-de-materias/toma-de-materias.ts
@@ -10,10 +10,10 @@ import {
 } from '../../services/academico/horario-actual.service';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { ApiService } from '../../services/api.service';
-import { TomaSeleccionService } from '../../services/academico/toma-seleccion.service';
 import { AuthSessionService } from '../../core/services/auth-session.service';
 import { PerfilService } from '../perfil/perfil.service';
 import { MallaCatalogoService, MallaMateria } from '../../services/academico/malla-catalogo.service';
+import { SeleccionTemporalService } from '../../services/academico/seleccion-temporal.service';
 
 export interface MateriaSeleccionada {
   id: number;
@@ -64,11 +64,11 @@ export class TomaDeMaterias implements OnInit {
   constructor(
     private readonly horarioActualService: HorarioActualService,
     private readonly apiService: ApiService,
-    private readonly tomaSeleccionService: TomaSeleccionService,
     private readonly authSessionService: AuthSessionService,
     private readonly perfilService: PerfilService,
     private readonly translateService: TranslateService,
     private readonly mallaCatalogoService: MallaCatalogoService,
+    private readonly seleccionTemporalService: SeleccionTemporalService,
   ) {}
 
   // Estadísticas de malla
@@ -81,10 +81,24 @@ export class TomaDeMaterias implements OnInit {
 
   ngOnInit(): void {
     this.cargarHorarioYSelecciones();
+    this.cargarSeleccionesTemporales();
+  }
 
-    this.tomaSeleccionService.seleccion$.subscribe(materias => {
-      this.materiasSeleccionadas = materias;
-      this.calcularTotalCreditos();
+  private cargarSeleccionesTemporales(): void {
+    this.seleccionTemporalService.listarSelecciones().subscribe({
+      next: (selecciones) => {
+        this.materiasSeleccionadas = selecciones.map((s) => ({
+          id: s.materiaId,
+          nombre: s.materiaNombre,
+          creditos: 0,
+          ofertaId: s.ofertaMateriaId,
+        }));
+        this.calcularTotalCreditos();
+      },
+      error: () => {
+        this.materiasSeleccionadas = [];
+        this.calcularTotalCreditos();
+      },
     });
   }
 
@@ -141,7 +155,17 @@ export class TomaDeMaterias implements OnInit {
   protected removerMateria(id: number): void {
     const confirmacion = window.confirm(this.translateService.instant('tomaMaterias.confirm.removeSubject'));
     if (confirmacion) {
-      this.tomaSeleccionService.removerMateria(id);
+      const materia = this.materiasSeleccionadas.find(m => m.id === id);
+      if (!materia) {
+        return;
+      }
+
+      this.seleccionTemporalService.removerSeleccion(materia.ofertaId).subscribe({
+        next: () => this.cargarSeleccionesTemporales(),
+        error: () => {
+          this.submitError = this.translateService.instant('tomaMaterias.messages.unexpectedRegistrationError');
+        },
+      });
     }
   }
 
@@ -169,8 +193,16 @@ export class TomaDeMaterias implements OnInit {
         const creditosNuevos = this.materiasSeleccionadas.reduce((sum, m) => sum + (Number(m.creditos) || 0), 0);
         this.creditosConfirmados += creditosNuevos;
 
-        this.tomaSeleccionService.limpiar();
-        this.cargarHorarioYSelecciones();
+        this.seleccionTemporalService.limpiarSelecciones().subscribe({
+          next: () => {
+            this.materiasSeleccionadas = [];
+            this.calcularTotalCreditos();
+            this.cargarHorarioYSelecciones();
+          },
+          error: () => {
+            this.cargarHorarioYSelecciones();
+          },
+        });
       },
       error: (err: HttpErrorResponse) => {
         this.submitLoading = false;

--- a/frontend/src/app/services/academico/malla-catalogo.service.spec.ts
+++ b/frontend/src/app/services/academico/malla-catalogo.service.spec.ts
@@ -8,7 +8,7 @@ describe('MallaCatalogoService', () => {
   let apiServiceSpy: jasmine.SpyObj<ApiService>;
 
   beforeEach(() => {
-    apiServiceSpy = jasmine.createSpyObj<ApiService>('ApiService', ['get']);
+    apiServiceSpy = jasmine.createSpyObj<ApiService>('ApiService', ['get', 'getBlob']);
     service = new MallaCatalogoService(apiServiceSpy);
   });
 
@@ -26,5 +26,13 @@ describe('MallaCatalogoService', () => {
     service.getMateriasPorMalla(16).subscribe();
 
     expect(apiServiceSpy.get).toHaveBeenCalledWith('/api/academico/mallas/16/materias');
+  });
+
+  it('calls graduation progress export endpoint', () => {
+    apiServiceSpy.getBlob.and.returnValue(of({} as any));
+
+    service.exportarAvanceGraduacion().subscribe();
+
+    expect(apiServiceSpy.getBlob).toHaveBeenCalledWith('/api/estudiantes/me/avance-graduacion/export');
   });
 });

--- a/frontend/src/app/services/academico/malla-catalogo.service.ts
+++ b/frontend/src/app/services/academico/malla-catalogo.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { ApiService } from '../api.service';
@@ -50,6 +51,10 @@ export class MallaCatalogoService {
 
   getMateriasPorMalla(mallaId: number): Observable<MallaMateria[]> {
     return this.apiService.get<MallaMateria[]>(`/api/academico/mallas/${mallaId}/materias`);
+  }
+
+  exportarAvanceGraduacion(): Observable<HttpResponse<Blob>> {
+    return this.apiService.getBlob('/api/estudiantes/me/avance-graduacion/export');
   }
 
    getDetallesMateria(mallaMateriaId: number): Observable<OfertaDetalleResponse> {

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -257,6 +257,15 @@
       "confirm": "Confirm import",
       "processing": "Processing...",
       "importSuccessToast": "Academic offers import completed successfully."
+    },
+    "export": {
+      "button": "Export progress",
+      "loading": "Exporting...",
+      "success": "Report downloaded successfully.",
+      "insufficientData": "There is not enough data to generate the report.",
+      "connectionError": "Could not connect to the server. Please try again.",
+      "downloadError": "Could not download the report. Please try again.",
+      "notAuthenticated": "Sign in to export your progress."
     }
   },
   "tomaMaterias": {

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -223,6 +223,15 @@
       "cancel": "Cancelar",
       "goToToma": "Ir a Toma de materias"
     },
+    "export": {
+      "button": "Exportar avance",
+      "loading": "Exportando...",
+      "success": "Reporte descargado correctamente.",
+      "insufficientData": "No existen datos suficientes para generar el reporte.",
+      "connectionError": "No se pudo conectar con el servidor. Intenta nuevamente.",
+      "downloadError": "No se pudo descargar el reporte. Intenta nuevamente.",
+      "notAuthenticated": "Inicia sesion para exportar tu avance."
+    },
     "validation": {
       "universidadRequired": "Debes seleccionar una universidad.",
       "carreraRequired": "Debes seleccionar una carrera.",

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -258,6 +258,15 @@
       "confirm": "Confirmar importação",
       "processing": "Processando...",
       "importSuccessToast": "Importação de ofertas concluída corretamente."
+    },
+    "export": {
+      "button": "Exportar avanço",
+      "loading": "Exportando...",
+      "success": "Relatório baixado com sucesso.",
+      "insufficientData": "Não há dados suficientes para gerar o relatório.",
+      "connectionError": "Não foi possível conectar ao servidor. Tente novamente.",
+      "downloadError": "Não foi possível baixar o relatório. Tente novamente.",
+      "notAuthenticated": "Inicie sessão para exportar seu avanço."
     }
   },
   "tomaMaterias": {


### PR DESCRIPTION
## Descripción
Agrega en la interfaz la descarga del avance de graduación generado por backend.

## Cambios principales
- Agrega botón visible para exportar avance desde la pantalla de malla.
- Llama al endpoint `GET /api/estudiantes/me/avance-graduacion/export`.
- Bloquea solicitudes duplicadas mientras se genera el reporte.
- Descarga automáticamente el archivo recibido.
- Usa el nombre de archivo enviado por backend o `avance_graduacion.pdf` como fallback.
- Muestra mensajes de éxito, falta de datos, error de conexión y falla de descarga.
- Evita exportar si el usuario no está autenticado.
- Mantiene la opción oculta cuando malla está deshabilitada por feature toggle.
- Agrega pruebas frontend para botón, endpoint, loading, descarga, filename y errores.

## Validación
- `npm test -- --watch=false --browsers=ChromeHeadless`
- `npm run build`