### PR TITLE
Hu148 confirmacion antes de acciones destructivas en malla ofertas

### DIFF
--- a/frontend/src/app/features/malla/importar-ofertas-modal/importar-ofertas-modal.html
+++ b/frontend/src/app/features/malla/importar-ofertas-modal/importar-ofertas-modal.html
@@ -168,7 +168,7 @@
       type="button"
       class="offers-button"
       [disabled]="hasCriticalErrors || preview.length === 0 || processing"
-      (click)="confirmImport()"
+      (click)="onConfirmImportClick()"
     >
       <span *ngIf="!processing">
         {{ 'malla.offers.confirm' | translate }}
@@ -180,3 +180,11 @@
     </button>
   </footer>
 </section>
+
+<app-confirm-modal
+  *ngIf="showConfirmModal"
+  title="confirmModal.defaultTitle"
+  message="confirmModal.importOfertas"
+  (confirm)="confirmImport()"
+  (cancel)="cancelConfirm()"
+></app-confirm-modal>

--- a/frontend/src/app/features/malla/importar-ofertas-modal/importar-ofertas-modal.ts
+++ b/frontend/src/app/features/malla/importar-ofertas-modal/importar-ofertas-modal.ts
@@ -17,6 +17,7 @@ import {
   OfertaImportSummaryResponse,
   OfertaImportWarningResponse,
 } from '../../../services/academico/oferta-import.service';
+import { ConfirmModal } from '../../../shared/ui/confirm-modal/confirm-modal';
 
 interface OfertaArchivoRow {
   rowNumber: number;
@@ -62,7 +63,7 @@ interface LocalImportWarning {
 
 @Component({
   selector: 'app-importar-ofertas-modal',
-  imports: [NgIf, NgFor, NgClass, TranslatePipe],
+  imports: [NgIf, NgFor, NgClass, TranslatePipe, ConfirmModal],
   templateUrl: './importar-ofertas-modal.html',
   styleUrl: './importar-ofertas-modal.scss',
 })
@@ -85,6 +86,7 @@ export class ImportarOfertasModal {
   protected processing = false;
   protected completed = false;
   protected totalRowsRead = 0;
+  protected showConfirmModal = false;
 
   protected requiredColumns = [
     'codigo_materia',
@@ -144,7 +146,23 @@ export class ImportarOfertasModal {
     this.closeModal.emit();
   }
 
+  protected onConfirmImportClick(): void {
+    if (
+      this.mallaId === null ||
+      this.selectedFile === null ||
+      this.hasCriticalErrors ||
+      this.preview.length === 0 ||
+      this.processing
+    ) {
+      return;
+    }
+
+    this.showConfirmModal = true;
+  }
+
   protected async confirmImport(): Promise<void> {
+    this.showConfirmModal = false;
+
     if (
       this.mallaId === null ||
       this.selectedFile === null ||
@@ -187,6 +205,10 @@ export class ImportarOfertasModal {
 
       this.processing = false;
     }
+  }
+
+  protected cancelConfirm(): void {
+    this.showConfirmModal = false;
   }
 
   private applyBackendResult(result: OfertaImportResultResponse): void {

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -613,7 +613,7 @@
           {{ 'malla.import.cancel' | translate }}
         </button>
         <button class="malla-button malla-button--save" 
-                (click)="importMalla()" 
+                (click)="onImportMallaClick()" 
                 [disabled]="!importFile || importLoading || !importMallaName || !isValidImportVersion()">
           <span *ngIf="importLoading">{{ 'malla.import.importing' | translate }}</span>
           <span *ngIf="!importLoading">{{ 'malla.import.import' | translate }}</span>
@@ -629,4 +629,12 @@
     (closeModal)="closeImportarOfertasModal()"
     (importFinished)="onOfertasImportFinished()"
   ></app-importar-ofertas-modal>
+
+  <app-confirm-modal
+    *ngIf="showConfirmModal"
+    [title]="confirmModalTitle"
+    [message]="confirmModalMessage"
+    (confirm)="onConfirmAction()"
+    (cancel)="onCancelConfirm()"
+  ></app-confirm-modal>
 </ng-container>

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -614,7 +614,7 @@
         </button>
         <button class="malla-button malla-button--save" 
                 (click)="onImportMallaClick()" 
-                [disabled]="!importFile || importLoading || !importMallaName || !isValidImportVersion()">
+                [disabled]="!canImportMalla()">
           <span *ngIf="importLoading">{{ 'malla.import.importing' | translate }}</span>
           <span *ngIf="!importLoading">{{ 'malla.import.import' | translate }}</span>
         </button>

--- a/frontend/src/app/features/malla/malla.spec.ts
+++ b/frontend/src/app/features/malla/malla.spec.ts
@@ -175,12 +175,24 @@ describe('Malla component logic', () => {
     expect((component as any).selectedMallaId).toBe(3);
   });
 
-  it('enables university change flow and resets dependent selectors', () => {
+  it('shows confirmation modal before university change', () => {
     (component as any).selectedUniversidadId = 1;
     (component as any).selectedCarreraId = 2;
     (component as any).selectedMallaId = 3;
 
     (component as any).onCambiarUniversidadClick();
+
+    expect((component as any).showConfirmModal).toBeTrue();
+    expect((component as any).pendingConfirmAction).toBe('changeUniversidad');
+  });
+
+  it('executes university change flow after confirmation', () => {
+    (component as any).selectedUniversidadId = 1;
+    (component as any).selectedCarreraId = 2;
+    (component as any).selectedMallaId = 3;
+
+    (component as any).onCambiarUniversidadClick();
+    (component as any).onConfirmAction();
 
     expect((component as any).editMode).toBe('universidad');
     expect((component as any).step).toBe('universidad');

--- a/frontend/src/app/features/malla/malla.spec.ts
+++ b/frontend/src/app/features/malla/malla.spec.ts
@@ -400,6 +400,80 @@ describe('Malla component logic', () => {
     expect(hasExportButton).toBeTrue();
   });
 
+  describe('HU-148 confirm modal edge cases', () => {
+    it('onImportMallaClick does not open modal when no file is selected', () => {
+      (component as any).importFile = null;
+      (component as any).importMallaName = 'Test';
+      (component as any).importMallaVersion = '2024';
+
+      (component as any).onImportMallaClick();
+
+      expect((component as any).showConfirmModal).toBeFalse();
+    });
+
+    it('onImportMallaClick does not open modal when name is empty', () => {
+      (component as any).importFile = new File([''], 'test.json');
+      (component as any).importMallaName = '';
+      (component as any).importMallaVersion = '2024';
+
+      (component as any).onImportMallaClick();
+
+      expect((component as any).showConfirmModal).toBeFalse();
+    });
+
+    it('onImportMallaClick does not open modal when version is invalid', () => {
+      (component as any).importFile = new File([''], 'test.json');
+      (component as any).importMallaName = 'Test';
+      (component as any).importMallaVersion = 'abc';
+
+      (component as any).onImportMallaClick();
+
+      expect((component as any).showConfirmModal).toBeFalse();
+    });
+
+    it('onImportMallaClick does not open modal while already loading', () => {
+      (component as any).importFile = new File([''], 'test.json');
+      (component as any).importMallaName = 'Test';
+      (component as any).importMallaVersion = '2024';
+      (component as any).importLoading = true;
+
+      (component as any).onImportMallaClick();
+
+      expect((component as any).showConfirmModal).toBeFalse();
+    });
+
+    it('opens modal when canImportMalla returns true', () => {
+      (component as any).importFile = new File([''], 'test.json');
+      (component as any).importMallaName = 'Test';
+      (component as any).importMallaVersion = '2024';
+
+      (component as any).onImportMallaClick();
+
+      expect((component as any).showConfirmModal).toBeTrue();
+      expect((component as any).pendingConfirmAction).toBe('importMalla');
+    });
+
+    it('clears pendingConfirmAction on cancel and does not execute any action', () => {
+      (component as any).pendingConfirmAction = 'changeUniversidad';
+      (component as any).showConfirmModal = true;
+
+      (component as any).onCancelConfirm();
+
+      expect((component as any).showConfirmModal).toBeFalse();
+      expect((component as any).pendingConfirmAction).toBeNull();
+    });
+
+    it('onConfirmAction calls ejecutarLimpiarSeleccion only once for clearSelection', () => {
+      spyOn(component as any, 'ejecutarLimpiarSeleccion');
+      (component as any).pendingConfirmAction = 'clearSelection';
+
+      (component as any).onConfirmAction();
+      (component as any).onConfirmAction();
+
+      expect((component as any).ejecutarLimpiarSeleccion).toHaveBeenCalledTimes(1);
+    });
+  });
+
   function buildBlobResponse(filename: string): HttpResponse<Blob> {
     return new HttpResponse({
       body: new Blob(['pdf'], { type: 'application/pdf' }),

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -1323,7 +1323,14 @@ Reglas obligatorias:
     }
   }
 
+  protected canImportMalla(): boolean {
+    return !!this.importFile && !this.importLoading && !!this.importMallaName.trim() && this.isValidImportVersion();
+  }
+
   public onImportMallaClick(): void {
+    if (!this.canImportMalla()) {
+      return;
+    }
     this.pendingConfirmAction = 'importMalla';
     this.confirmModalTitle = 'confirmModal.defaultTitle';
     this.confirmModalMessage = 'confirmModal.importMalla';

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -26,6 +26,7 @@ import { TourHintsService } from '../../services/tour-hints.service';
 import { SeleccionTemporalService, SeleccionTemporalResponse } from '../../services/academico/seleccion-temporal.service';
 
 import { ImportarOfertasModal } from './importar-ofertas-modal/importar-ofertas-modal';
+import { ConfirmModal } from '../../shared/ui/confirm-modal/confirm-modal';
 
 type SeleccionStep = 'universidad' | 'carrera' | 'malla' | 'resumen';
 type EditMode = 'universidad' | 'malla' | null;
@@ -46,6 +47,7 @@ interface SeleccionSnapshot {
     TranslatePipe,
     NgbPopoverModule,
     ImportarOfertasModal,
+    ConfirmModal,
   ],
   templateUrl: './malla.html',
   styleUrl: './malla.scss',
@@ -121,6 +123,11 @@ export class Malla implements OnInit, OnDestroy {
   protected prereqGuardando = false;
   protected prereqError: string | null = null;
   protected prereqSuccess: string | null = null;
+
+  protected showConfirmModal = false;
+  protected pendingConfirmAction: 'changeMalla' | 'changeUniversidad' | 'clearSelection' | 'importMalla' | null = null;
+  protected confirmModalMessage = 'confirmModal.defaultMessage';
+  protected confirmModalTitle = 'confirmModal.defaultTitle';
 
   protected tourStep = 0;
 
@@ -238,12 +245,10 @@ Reglas obligatorias:
   }
 
   protected onCambiarUniversidadClick(): void {
-    this.editMode = 'universidad';
-    this.step = 'universidad';
-    this.mallaChangeWarningVisible = false;
-    this.clearErrors();
-    this.createSelectionSnapshot();
-    this.onUniversidadChange(null);
+    this.pendingConfirmAction = 'changeUniversidad';
+    this.confirmModalTitle = 'confirmModal.defaultTitle';
+    this.confirmModalMessage = 'confirmModal.changeUniversidad';
+    this.showConfirmModal = true;
   }
 
   protected onCambiarMallaClick(): void {
@@ -427,11 +432,11 @@ Reglas obligatorias:
       const isChangingMalla = mallaAnteriorId !== null && this.selectedMallaId !== mallaAnteriorId;
 
       if (isChangingMalla) {
-        const confirmed = window.confirm(this.translateService.instant('malla.modal.confirmChangeMalla'));
-
-        if (!confirmed) {
-          return;
-        }
+        this.pendingConfirmAction = 'changeMalla';
+        this.confirmModalTitle = 'confirmModal.defaultTitle';
+        this.confirmModalMessage = 'confirmModal.changeMalla';
+        this.showConfirmModal = true;
+        return;
       }
     }
 
@@ -751,18 +756,10 @@ Reglas obligatorias:
   }
 
   protected cancelarSeleccion(): void {
-    if (confirm(this.translateService.instant('malla.selection.confirmClear'))) {
-      this.seleccionTemporalService.limpiarSelecciones().subscribe({
-        next: () => {
-          this.seleccionesTemporales = [];
-          this.showFloatingPanel = false;
-          this.toastService.success('malla.selection.cleared');
-        },
-        error: () => {
-          this.toastService.error('malla.selection.errorClear');
-        }
-      });
-    }
+    this.pendingConfirmAction = 'clearSelection';
+    this.confirmModalTitle = 'confirmModal.defaultTitle';
+    this.confirmModalMessage = 'confirmModal.clearSelection';
+    this.showConfirmModal = true;
   }
 
   protected closeModal(): void {
@@ -1324,6 +1321,69 @@ Reglas obligatorias:
       this.importFileName = file.name;
       this.importError = null;
     }
+  }
+
+  public onImportMallaClick(): void {
+    this.pendingConfirmAction = 'importMalla';
+    this.confirmModalTitle = 'confirmModal.defaultTitle';
+    this.confirmModalMessage = 'confirmModal.importMalla';
+    this.showConfirmModal = true;
+  }
+
+  protected onConfirmAction(): void {
+    const action = this.pendingConfirmAction;
+    this.showConfirmModal = false;
+    this.pendingConfirmAction = null;
+
+    switch (action) {
+      case 'changeMalla':
+        void this.ejecutarGuardarSeleccion();
+        break;
+      case 'changeUniversidad':
+        this.ejecutarCambioUniversidad();
+        break;
+      case 'clearSelection':
+        this.ejecutarLimpiarSeleccion();
+        break;
+      case 'importMalla':
+        void this.ejecutarImportMalla();
+        break;
+    }
+  }
+
+  protected onCancelConfirm(): void {
+    this.showConfirmModal = false;
+    this.pendingConfirmAction = null;
+  }
+
+  private ejecutarCambioUniversidad(): void {
+    this.editMode = 'universidad';
+    this.step = 'universidad';
+    this.mallaChangeWarningVisible = false;
+    this.clearErrors();
+    this.createSelectionSnapshot();
+    this.onUniversidadChange(null);
+  }
+
+  private ejecutarLimpiarSeleccion(): void {
+    this.seleccionTemporalService.limpiarSelecciones().subscribe({
+      next: () => {
+        this.seleccionesTemporales = [];
+        this.showFloatingPanel = false;
+        this.toastService.success('malla.selection.cleared');
+      },
+      error: () => {
+        this.toastService.error('malla.selection.errorClear');
+      }
+    });
+  }
+
+  private async ejecutarGuardarSeleccion(): Promise<void> {
+    await this.guardarSeleccion();
+  }
+
+  private async ejecutarImportMalla(): Promise<void> {
+    await this.importMalla();
   }
 
   public async importMalla(): Promise<void> {

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
@@ -1,24 +1,30 @@
-<div class="confirm-overlay">
-  <div class="confirm-modal">
-    <header class="confirm-modal__header">
-      <div>
-        <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
-        <h3>{{ title | translate }}</h3>
-      </div>
-      <button type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
-    </header>
+<div class="confirm-overlay" (click)="onCancel()"></div>
 
-    <div class="confirm-modal__body">
-      <p>{{ message | translate }}</p>
+<div
+  class="confirm-modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="confirm-title"
+  aria-describedby="confirm-message"
+>
+  <header class="confirm-modal__header">
+    <div>
+      <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
+      <h3 id="confirm-title">{{ title | translate }}</h3>
     </div>
+    <button #focusTrapStart type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
+  </header>
 
-    <footer class="confirm-modal__footer">
-      <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()">
-        {{ cancelLabel | translate }}
-      </button>
-      <button type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()">
-        {{ confirmLabel | translate }}
-      </button>
-    </footer>
+  <div class="confirm-modal__body">
+    <p id="confirm-message">{{ message | translate }}</p>
   </div>
+
+  <footer class="confirm-modal__footer">
+    <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()" [disabled]="processing">
+      {{ cancelLabel | translate }}
+    </button>
+    <button #confirmBtn #focusTrapEnd type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()" [disabled]="processing">
+      {{ confirmLabel | translate }}
+    </button>
+  </footer>
 </div>

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
@@ -1,0 +1,24 @@
+<div class="confirm-overlay">
+  <div class="confirm-modal">
+    <header class="confirm-modal__header">
+      <div>
+        <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
+        <h3>{{ title | translate }}</h3>
+      </div>
+      <button type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
+    </header>
+
+    <div class="confirm-modal__body">
+      <p>{{ message | translate }}</p>
+    </div>
+
+    <footer class="confirm-modal__footer">
+      <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()">
+        {{ cancelLabel | translate }}
+      </button>
+      <button type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()">
+        {{ confirmLabel | translate }}
+      </button>
+    </footer>
+  </div>
+</div>

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
@@ -1,0 +1,109 @@
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(12, 18, 28, 0.54);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  backdrop-filter: blur(1px);
+}
+
+.confirm-modal {
+  width: min(420px, 96vw);
+  border-radius: 16px;
+  border: 1px solid rgba(47, 79, 115, 0.26);
+  background:
+    radial-gradient(circle at 92% 12%, rgba(111, 137, 173, 0.18), transparent 30%),
+    #f7f3e7;
+  box-shadow: 0 20px 48px rgba(11, 20, 33, 0.34);
+}
+
+.confirm-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1rem 0.55rem;
+  border-bottom: 1px solid rgba(47, 79, 115, 0.18);
+
+  h3 {
+    margin: 0.15rem 0 0;
+    color: #121722;
+    font-family: 'Poppins', sans-serif;
+    font-size: clamp(1.35rem, 1.15rem + 0.55vw, 1.7rem);
+  }
+}
+
+.confirm-modal__eyebrow {
+  margin: 0;
+  color: #2c4f73;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.confirm-modal__close {
+  border: 1px solid rgba(47, 79, 115, 0.25);
+  border-radius: 8px;
+  background: #fff;
+  color: #1f2d3c;
+  width: 2rem;
+  height: 2rem;
+  line-height: 1;
+  font-size: 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.confirm-modal__body {
+  padding: 1.2rem 1rem;
+}
+
+.confirm-modal__body p {
+  margin: 0;
+  color: rgba(17, 17, 17, 0.9);
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.confirm-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  padding: 0.65rem 1rem 1rem;
+  border-top: 1px solid rgba(47, 79, 115, 0.14);
+}
+
+.confirm-btn {
+  margin-top: 0;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.5rem 0.9rem;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+}
+
+.confirm-btn--ghost {
+  border: 1px solid rgba(47, 79, 115, 0.25);
+  background: transparent;
+  color: var(--color-blue-dark);
+}
+
+.confirm-btn--danger {
+  background: #a32017;
+  color: #fff;
+}
+
+.confirm-btn--danger:hover {
+  background: #8a1b14;
+}

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.ts
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, HostListener, Input, Output, ViewChild } from '@angular/core';
 import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
@@ -8,20 +8,57 @@ import { TranslatePipe } from '@ngx-translate/core';
   templateUrl: './confirm-modal.html',
   styleUrl: './confirm-modal.scss',
 })
-export class ConfirmModal {
-  @Input() title = 'confirmModal.defaultTitle';
-  @Input() message = 'confirmModal.defaultMessage';
+export class ConfirmModal implements AfterViewInit {
+  @Input({ required: true }) title = 'confirmModal.defaultTitle';
+  @Input({ required: true }) message = 'confirmModal.defaultMessage';
   @Input() confirmLabel = 'confirmModal.confirm';
   @Input() cancelLabel = 'confirmModal.cancel';
 
   @Output() confirm = new EventEmitter<void>();
   @Output() cancel = new EventEmitter<void>();
 
+  @ViewChild('focusTrapStart') focusTrapStart!: ElementRef<HTMLButtonElement>;
+  @ViewChild('focusTrapEnd') focusTrapEnd!: ElementRef<HTMLButtonElement>;
+  @ViewChild('confirmBtn') confirmBtn!: ElementRef<HTMLButtonElement>;
+
+  protected processing = false;
+
+  ngAfterViewInit(): void {
+    this.confirmBtn?.nativeElement?.focus();
+  }
+
+  @HostListener('keydown', ['$event'])
+  protected handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.onCancel();
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    if (event.shiftKey && event.target === this.focusTrapStart?.nativeElement) {
+      event.preventDefault();
+      this.focusTrapEnd?.nativeElement?.focus();
+      return;
+    }
+    if (!event.shiftKey && event.target === this.focusTrapEnd?.nativeElement) {
+      event.preventDefault();
+      this.focusTrapStart?.nativeElement?.focus();
+    }
+  }
+
   protected onConfirm(): void {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
     this.confirm.emit();
   }
 
   protected onCancel(): void {
+    if (this.processing) {
+      return;
+    }
     this.cancel.emit();
   }
 }

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.ts
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.ts
@@ -1,0 +1,27 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-confirm-modal',
+  standalone: true,
+  imports: [TranslatePipe],
+  templateUrl: './confirm-modal.html',
+  styleUrl: './confirm-modal.scss',
+})
+export class ConfirmModal {
+  @Input() title = 'confirmModal.defaultTitle';
+  @Input() message = 'confirmModal.defaultMessage';
+  @Input() confirmLabel = 'confirmModal.confirm';
+  @Input() cancelLabel = 'confirmModal.cancel';
+
+  @Output() confirm = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  protected onConfirm(): void {
+    this.confirm.emit();
+  }
+
+  protected onCancel(): void {
+    this.cancel.emit();
+  }
+}

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -9,6 +9,18 @@
       "codePT": "PT"
     }
   },
+  "confirmModal": {
+    "title": "Confirm action",
+    "defaultTitle": "Are you sure?",
+    "defaultMessage": "This action cannot be undone.",
+    "confirm": "Yes, confirm",
+    "cancel": "Cancel",
+    "changeMalla": "Changing the curriculum will reset your progress from the previous one. Do you want to continue?",
+    "changeUniversidad": "Changing the university will discard the current configuration. Do you want to continue?",
+    "clearSelection": "Are you sure you want to clear your temporary selection?",
+    "importMalla": "A new curriculum will be imported. This action will create records in the system. Do you want to continue?",
+    "importOfertas": "Academic offers will be imported for the current curriculum. This action will create or update records. Do you want to continue?"
+  },
   "toast": {
     "dismiss": "Close notification"
   },

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -9,6 +9,18 @@
       "codePT": "PT"
     }
   },
+  "confirmModal": {
+    "title": "Confirmar acción",
+    "defaultTitle": "¿Estás seguro?",
+    "defaultMessage": "Esta acción no se puede deshacer.",
+    "confirm": "Sí, confirmar",
+    "cancel": "Cancelar",
+    "changeMalla": "Al cambiar de malla se perderá el progreso de la malla anterior. ¿Deseas continuar?",
+    "changeUniversidad": "Al cambiar de universidad se perderá la configuración actual. ¿Deseas continuar?",
+    "clearSelection": "¿Estás seguro de que deseas limpiar tu selección temporal?",
+    "importMalla": "Se importará una nueva malla curricular. Esta acción creará registros en el sistema. ¿Deseas continuar?",
+    "importOfertas": "Se importarán las ofertas académicas para la malla actual. Esta acción creará o actualizará registros. ¿Deseas continuar?"
+  },
   "toast": {
     "dismiss": "Cerrar aviso"
   },


### PR DESCRIPTION
**Description:**
Muestra un modal de confirmación antes de ejecutar acciones irreversibles como:
- Cambiar de universidad o malla
- Limpiar selección temporal de materias
- Importar ofertas académicas
El modal tiene un botón de "Cancelar" (no hace nada) y otro de confirmación (ejecuta la acción), evitando eliminaciones o cambios por error.

**ScreenShots:**
<img width="1897" height="870" alt="image" src="https://github.com/user-attachments/assets/25cd73c6-0ca7-46f9-9c68-0a99a50733d9" />
<img width="1895" height="861" alt="image" src="https://github.com/user-attachments/assets/72d1b5f4-365a-4ed7-a6cb-95ff47110c4a" />

**Test:**
<img width="1297" height="383" alt="image" src="https://github.com/user-attachments/assets/4d161ba0-f7dc-447f-baa2-de9a6c20c95f" />
<img width="1265" height="617" alt="image" src="https://github.com/user-attachments/assets/c32f0648-36ee-4954-a63a-e1a128a74ea6" />
