### PR TITLE
HU152 Estandarizacion de i18n

### DIFF
--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -186,6 +186,7 @@
     },
     "loadingCarreras": "Loading careers...",
     "loadingMallas": "Loading curricula...",
+    "loadingMaterias": "Loading subjects...",
     "steps": {
       "universidad": "University",
       "carrera": "Career",
@@ -225,7 +226,18 @@
       "noGroupsAvailable": "This subject currently has no available groups.",
       "takeSubject": "Take subject",
       "cancel": "Cancel",
-      "addToSelection": "Add to selection"
+      "addToSelection": "Add to selection",
+      "closeAria": "Close import modal"
+    },
+    "selection": {
+      "added": "Subject added successfully",
+      "errorAdd": "Could not add the subject",
+      "confirmClear": "Are you sure you want to clear your temporary selection?",
+      "cleared": "Temporary selection cleared",
+      "errorClear": "Error clearing the selection",
+      "panelTitle": "Temporary selection",
+      "cancel": "Cancel",
+      "goToToma": "Go to Course Selection"
     },
     "UpdateCourse": {
       "title": "Course status",

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -126,6 +126,7 @@
     "loadingUniversidades": "Cargando universidades...",
     "loadingCarreras": "Cargando carreras...",
     "loadingMallas": "Cargando mallas...",
+    "loadingMaterias": "Cargando materias...",
     "retry": "Reintentar",
     "steps": {
       "universidad": "Universidad",
@@ -221,6 +222,7 @@
       "takeSubject": "Tomar materia",
       "cancel": "Cancelar",
       "addToSelection": "Agregar a seleccion",
+      "closeAria": "Cerrar modal de importación",
       "added": "Materia agregada a tu seleccion temporal"
     },
     "selection": {

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -245,7 +245,18 @@
       "noGroupsAvailable": "Esta matéria não possui grupos disponíveis no momento.",
       "takeSubject": "Tomar matéria",
       "cancel": "Cancelar",
-      "addToSelection": "Adicionar à seleção"
+      "addToSelection": "Adicionar à seleção",
+      "closeAria": "Fechar modal de importação"
+    },
+    "selection": {
+      "added": "Matéria adicionada com sucesso",
+      "errorAdd": "Não foi possível adicionar a matéria",
+      "confirmClear": "Tem certeza de que deseja limpar sua seleção temporária?",
+      "cleared": "Seleção temporária limpa",
+      "errorClear": "Erro ao limpar a seleção",
+      "panelTitle": "Seleção temporária",
+      "cancel": "Cancelar",
+      "goToToma": "Ir para Seleção de Disciplinas"
     },
     "offers": {
       "eyebrow": "Ofertas acadêmicas",


### PR DESCRIPTION
**Description:**
Se agregaron las keys i18n faltantes de malla.loadingMaterias, malla.modal.closeAria y todo malla.selection.* en ES, EN y PT para que todos los textos nuevos del sprint tengan traducción en los 3 idiomas.

**Screens:**
<img width="1880" height="863" alt="image" src="https://github.com/user-attachments/assets/75606fa2-851b-438b-b82e-7bd53e8624f1" />
<img width="1888" height="860" alt="image" src="https://github.com/user-attachments/assets/c2aff0c9-68e4-4378-87b6-ddfb9f77d6aa" />
<img width="1890" height="870" alt="image" src="https://github.com/user-attachments/assets/2dc096de-cb38-4627-8861-f6e0f6d042ad" />

**Test: **
<img width="1251" height="587" alt="image" src="https://github.com/user-attachments/assets/c80d20a8-e204-4df5-b1df-4c906b952071" />
