### PR TITLE
HU-150 Fallback seguro feature toggles

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsController.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsController.java
@@ -8,18 +8,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/features")
 public class FeatureFlagsController {
 
-    private final FeatureFlagsConfig featureFlagsConfig;
+    private final FeatureFlagsService featureFlagsService;
 
-    public FeatureFlagsController(FeatureFlagsConfig featureFlagsConfig) {
-        this.featureFlagsConfig = featureFlagsConfig;
+    public FeatureFlagsController(FeatureFlagsService featureFlagsService) {
+        this.featureFlagsService = featureFlagsService;
     }
 
     @GetMapping
     public FeatureFlagsDTO getFeatureFlags() {
-        return new FeatureFlagsDTO(
-            featureFlagsConfig.isMalla(),
-            featureFlagsConfig.isTomaMaterias(),
-            featureFlagsConfig.isOfertasImport()
-        );
+        return featureFlagsService.getFeatureFlags();
     }
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDefaults.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDefaults.java
@@ -1,0 +1,19 @@
+package com.easyschedule.backend.shared.feature;
+
+public final class FeatureFlagsDefaults {
+
+    public static final boolean MALLA_ENABLED = true;
+    public static final boolean TOMA_MATERIAS_ENABLED = true;
+    public static final boolean OFERTAS_IMPORT_ENABLED = false;
+
+    private FeatureFlagsDefaults() {
+    }
+
+    public static FeatureFlagsDTO safeDefaults() {
+        return new FeatureFlagsDTO(
+            MALLA_ENABLED,
+            TOMA_MATERIAS_ENABLED,
+            OFERTAS_IMPORT_ENABLED
+        );
+    }
+}

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsService.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsService.java
@@ -1,0 +1,38 @@
+package com.easyschedule.backend.shared.feature;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeatureFlagsService {
+
+    private static final Logger log = LoggerFactory.getLogger(FeatureFlagsService.class);
+
+    private final FeatureFlagsConfig featureFlagsConfig;
+
+    public FeatureFlagsService(FeatureFlagsConfig featureFlagsConfig) {
+        this.featureFlagsConfig = featureFlagsConfig;
+    }
+
+    public FeatureFlagsDTO getFeatureFlags() {
+        try {
+            return new FeatureFlagsDTO(
+                featureFlagsConfig.isMalla(),
+                featureFlagsConfig.isTomaMaterias(),
+                featureFlagsConfig.isOfertasImport()
+            );
+        } catch (RuntimeException ex) {
+            FeatureFlagsDTO fallback = FeatureFlagsDefaults.safeDefaults();
+            log.warn(
+                "[FEATURE_TOGGLES_FALLBACK] No se pudo leer la configuracion de feature toggles. "
+                    + "Aplicando defaults seguros: malla={}, tomaMaterias={}, ofertasImport={}",
+                fallback.malla(),
+                fallback.tomaMaterias(),
+                fallback.ofertasImport(),
+                ex
+            );
+            return fallback;
+        }
+    }
+}

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
@@ -10,7 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
-@ConditionalOnBean(FeatureFlagsConfig.class)
+@ConditionalOnBean(FeatureFlagsService.class)
 public class FeatureToggleInterceptor implements HandlerInterceptor {
 
     private static final List<String> MALLA_PATH_PREFIXES = List.of(
@@ -32,25 +32,26 @@ public class FeatureToggleInterceptor implements HandlerInterceptor {
         "/api/academico/horario"
     );
 
-    private final FeatureFlagsConfig featureFlagsConfig;
+    private final FeatureFlagsService featureFlagsService;
 
-    public FeatureToggleInterceptor(FeatureFlagsConfig featureFlagsConfig) {
-        this.featureFlagsConfig = featureFlagsConfig;
+    public FeatureToggleInterceptor(FeatureFlagsService featureFlagsService) {
+        this.featureFlagsService = featureFlagsService;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String requestPath = request.getRequestURI();
+        FeatureFlagsDTO featureFlags = featureFlagsService.getFeatureFlags();
 
-        if (!featureFlagsConfig.isMalla() && matchesAny(requestPath, MALLA_PATH_PREFIXES)) {
+        if (!featureFlags.malla() && matchesAny(requestPath, MALLA_PATH_PREFIXES)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La funcionalidad de malla esta deshabilitada");
         }
 
-        if (!featureFlagsConfig.isOfertasImport() && matchesAny(requestPath, OFERTAS_IMPORT_PATH_PREFIXES)) {
+        if (!featureFlags.ofertasImport() && matchesAny(requestPath, OFERTAS_IMPORT_PATH_PREFIXES)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La importacion de ofertas esta deshabilitada");
         }
 
-        if (!featureFlagsConfig.isTomaMaterias() && matchesAny(requestPath, TOMA_MATERIAS_PATH_PREFIXES)) {
+        if (!featureFlags.tomaMaterias() && matchesAny(requestPath, TOMA_MATERIAS_PATH_PREFIXES)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La funcionalidad de toma de materias esta deshabilitada");
         }
 

--- a/backend/src/main/resources/docs/feature-toggle-fallback.md
+++ b/backend/src/main/resources/docs/feature-toggle-fallback.md
@@ -1,0 +1,11 @@
+# Feature Toggle Fallback
+
+Si la lectura de feature toggles falla temporalmente, el backend no debe cortar el servicio completo. El sistema intenta leer la configuracion activa en cada request y, ante una excepcion, registra un evento `FEATURE_TOGGLES_FALLBACK` en logs y aplica defaults seguros.
+
+Defaults seguros:
+
+- `malla`: habilitado, porque permite mantener disponible la configuracion academica principal.
+- `tomaMaterias`: habilitado, porque evita indisponibilidad del flujo academico principal.
+- `ofertasImport`: deshabilitado, porque la importacion modifica datos academicos de forma masiva y es mas segura apagada ante incertidumbre.
+
+El fallback no se cachea. Cuando la configuracion vuelve a estar disponible, la siguiente lectura usa automaticamente los valores configurados.

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsServiceTest.java
@@ -1,0 +1,59 @@
+package com.easyschedule.backend.shared.feature;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+class FeatureFlagsServiceTest {
+
+    @Test
+    void returnsConfiguredFlagsWhenConfigIsAvailable() {
+        FeatureFlagsConfig config = mock(FeatureFlagsConfig.class);
+        when(config.isMalla()).thenReturn(false);
+        when(config.isTomaMaterias()).thenReturn(true);
+        when(config.isOfertasImport()).thenReturn(false);
+
+        FeatureFlagsDTO flags = new FeatureFlagsService(config).getFeatureFlags();
+
+        assertFalse(flags.malla());
+        assertTrue(flags.tomaMaterias());
+        assertFalse(flags.ofertasImport());
+    }
+
+    @Test
+    void returnsSafeDefaultsWhenConfigReadFails() {
+        FeatureFlagsConfig config = mock(FeatureFlagsConfig.class);
+        when(config.isMalla()).thenThrow(new IllegalStateException("toggle source unavailable"));
+
+        FeatureFlagsDTO flags = new FeatureFlagsService(config).getFeatureFlags();
+
+        assertTrue(flags.malla());
+        assertTrue(flags.tomaMaterias());
+        assertFalse(flags.ofertasImport());
+    }
+
+    @Test
+    void retriesConfigAfterFallbackOnNextRead() {
+        FeatureFlagsConfig config = mock(FeatureFlagsConfig.class);
+        when(config.isMalla())
+            .thenThrow(new IllegalStateException("temporary failure"))
+            .thenReturn(false);
+        when(config.isTomaMaterias()).thenReturn(false);
+        when(config.isOfertasImport()).thenReturn(true);
+
+        FeatureFlagsService service = new FeatureFlagsService(config);
+
+        FeatureFlagsDTO fallback = service.getFeatureFlags();
+        FeatureFlagsDTO recovered = service.getFeatureFlags();
+
+        assertTrue(fallback.malla());
+        assertTrue(fallback.tomaMaterias());
+        assertFalse(fallback.ofertasImport());
+        assertFalse(recovered.malla());
+        assertFalse(recovered.tomaMaterias());
+        assertTrue(recovered.ofertasImport());
+    }
+}

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptorTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptorTest.java
@@ -1,0 +1,43 @@
+package com.easyschedule.backend.shared.feature;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.server.ResponseStatusException;
+
+class FeatureToggleInterceptorTest {
+
+    @Test
+    void allowsCoreAcademicPathWhenFallbackDefaultsAreApplied() {
+        FeatureFlagsService service = mock(FeatureFlagsService.class);
+        when(service.getFeatureFlags()).thenReturn(FeatureFlagsDefaults.safeDefaults());
+        FeatureToggleInterceptor interceptor = new FeatureToggleInterceptor(service);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/academico/mallas");
+
+        boolean allowed = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        assertTrue(allowed);
+    }
+
+    @Test
+    void blocksOfferImportPathWhenFallbackDefaultsAreApplied() {
+        FeatureFlagsService service = mock(FeatureFlagsService.class);
+        when(service.getFeatureFlags()).thenReturn(FeatureFlagsDefaults.safeDefaults());
+        FeatureToggleInterceptor interceptor = new FeatureToggleInterceptor(service);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/academico/ofertas/importar");
+
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> interceptor.preHandle(request, new MockHttpServletResponse(), new Object())
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    }
+}


### PR DESCRIPTION
## Resumen
Se agregó un fallback seguro para feature toggles en backend, evitando caída del servicio si falla la lectura de configuración.

## Cambios principales
- Se creó `FeatureFlagsService` para centralizar la lectura de feature toggles.
- Se definieron defaults seguros:
  - `malla`: habilitado
  - `tomaMaterias`: habilitado
  - `ofertasImport`: deshabilitado
- El backend registra un warning cuando aplica fallback.
- El interceptor usa el servicio con fallback, evitando caídas por errores temporales.
- Se documentó el comportamiento por defecto.
- Se agregaron tests unitarios para fallback y recuperación.
