### PR TITLE
HU-143 Correccion conexion registro login

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,4 +2,4 @@ SPRING_PROFILES_ACTIVE=dev
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/EasySchedule
 SPRING_DATASOURCE_USERNAME=postgres
 SPRING_DATASOURCE_PASSWORD=EasySchedule
-CORS_ALLOWED_ORIGINS=http://localhost:4200
+CORS_ALLOWED_ORIGINS=http://localhost:4200,https://easyschedule2.netlify.app

--- a/backend/src/main/java/com/easyschedule/backend/CorsConfig.java
+++ b/backend/src/main/java/com/easyschedule/backend/CorsConfig.java
@@ -14,6 +14,11 @@ import java.util.List;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = List.of(
+        "http://localhost:4200",
+        "https://easyschedule2.netlify.app"
+    );
+
     @Value("${app.cors.allowed-origins:http://localhost:4200}")
     private String allowedOrigins;
 
@@ -29,6 +34,10 @@ public class CorsConfig implements WebMvcConfigurer {
             .map(String::trim)
             .filter((origin) -> !origin.isEmpty())
             .toList();
+
+        if (originPatterns.isEmpty()) {
+            originPatterns = DEFAULT_ALLOWED_ORIGINS;
+        }
 
         registry.addMapping("/**")
             .allowedOriginPatterns(originPatterns.toArray(String[]::new))

--- a/frontend/src/app/features/login/login.ts
+++ b/frontend/src/app/features/login/login.ts
@@ -171,9 +171,11 @@ export class LoginComponent implements AfterViewInit {
       await this.finishAuthenticatedLogin(data);
     } catch (error: any) {
       const status = Number(error?.status ?? 0);
-      const messageKey = status === 401
-        ? 'login.error.googleInvalid'
-        : 'login.error.googleGeneric';
+      const messageKey = status === 0
+        ? 'login.error.backendConnection'
+        : status === 401
+          ? 'login.error.googleInvalid'
+          : 'login.error.googleGeneric';
 
       this.toastService.error(messageKey);
       this.authSessionService.clearSession();
@@ -246,9 +248,11 @@ export class LoginComponent implements AfterViewInit {
 
     } catch (error: any) {
       const status = Number(error?.status ?? 0);
-      const messageKey = status === 401
-        ? 'login.error.invalidCredentials'
-        : 'login.error.generic';
+      const messageKey = status === 0
+        ? 'login.error.backendConnection'
+        : status === 401
+          ? 'login.error.invalidCredentials'
+          : 'login.error.generic';
       this.toastService.error(messageKey);
       this.authSessionService.clearSession();
     } finally {

--- a/frontend/src/app/features/registro/registro.ts
+++ b/frontend/src/app/features/registro/registro.ts
@@ -195,9 +195,11 @@ export class Registro implements AfterViewInit {
       await this.finishGoogleAuthenticatedFlow(data);
     } catch (error: any) {
       const status = Number(error?.status ?? 0);
-      const messageKey = status === 401
-        ? 'registro.error.googleInvalid'
-        : 'registro.error.googleGeneric';
+      const messageKey = status === 0
+        ? 'registro.error.backendConnection'
+        : status === 401
+          ? 'registro.error.googleInvalid'
+          : 'registro.error.googleGeneric';
 
       this.toastService.error(messageKey);
       this.authSessionService.clearSession();

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -122,7 +122,8 @@
     },
     "error": {
       "invalidCredentials": "Invalid credentials",
-      "generic": "Unexpected error",
+      "generic": "We could not complete sign-in. Please try again.",
+      "backendConnection": "We could not reach the service right now. Please try again in a few minutes.",
       "googleUnavailable": "Could not load Google Sign-In. Please try again.",
       "googleCancelled": "No Google credential received.",
       "googleInvalid": "Could not sign in with Google. Please try again.",
@@ -567,7 +568,7 @@
       "emailExists": "Email is already registered",
       "weakPassword": "Password does not meet security policy",
       "invalidData": "Invalid data",
-      "backendConnection": "Could not connect to backend",
+      "backendConnection": "We could not reach the service right now. Please try again in a few minutes.",
       "server": "Server error. Please try again",
       "googleUnavailable": "Could not load Google Sign-In. Please try again.",
       "googleCancelled": "No Google credential received.",

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -122,7 +122,8 @@
   },
   "error": {
     "invalidCredentials": "Credenciales inválidas",
-    "generic": "Error inesperado",
+    "generic": "No pudimos completar el inicio de sesión. Intenta nuevamente.",
+    "backendConnection": "No pudimos conectar con el servicio en este momento. Intenta nuevamente en unos minutos.",
     "googleUnavailable": "No se pudo cargar Google Sign-In. Intenta nuevamente.",
     "googleCancelled": "No se recibió una credencial de Google.",
     "googleInvalid": "No se pudo iniciar sesión con Google. Intenta nuevamente.",
@@ -578,7 +579,7 @@
       "emailExists": "El correo ya está registrado",
       "weakPassword": "La contraseña no cumple la política de seguridad",
       "invalidData": "Datos inválidos",
-      "backendConnection": "No se pudo conectar con el backend",
+      "backendConnection": "No pudimos conectar con el servicio en este momento. Intenta nuevamente en unos minutos.",
       "server": "Error del servidor. Intenta nuevamente",
       "googleUnavailable": "No se pudo cargar Google Sign-In. Intenta nuevamente.",
       "googleCancelled": "No se recibió una credencial de Google.",

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -110,9 +110,12 @@
     },
     "error": {
       "invalidCredentials": "Credenciais inválidas",
-      "generic": "Erro inesperado",
+      "generic": "Não foi possível concluir o login. Tente novamente.",
+      "backendConnection": "Não conseguimos acessar o serviço agora. Tente novamente em alguns minutos.",
       "googleUnavailable": "Não foi possível carregar o Login com Google. Por favor, tente novamente.",
-      "googleCancelled": "Nenhuma credencial do Google recebida."
+      "googleCancelled": "Nenhuma credencial do Google recebida.",
+      "googleInvalid": "Não foi possível entrar com Google. Tente novamente.",
+      "googleGeneric": "Ocorreu um erro ao entrar com Google."
     },
     "divider": {
       "or": "ou"
@@ -553,7 +556,7 @@
       "emailExists": "O email já está registrado",
       "weakPassword": "A senha não atende à política de segurança",
       "invalidData": "Dados inválidos",
-      "backendConnection": "Não foi possível conectar ao backend",
+      "backendConnection": "Não conseguimos acessar o serviço agora. Tente novamente em alguns minutos.",
       "server": "Erro no servidor. Tente novamente",
       "googleUnavailable": "Não foi possível carregar o Cadastro com Google. Tente novamente.",
       "googleCancelled": "Nenhuma credencial do Google recebida.",

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  backendUrl: 'https://easyschedule-hjzc.onrender.com',
+  backendUrl: '',
   googleClientId: '692611066828-hnsrfqs4kpi6dbf8427qi33tcvmde4dk.apps.googleusercontent.com'
 };


### PR DESCRIPTION
## Resumen
Se corrigió la conexión frontend-backend para los flujos de registro e inicio de sesión en producción.

## Cambios principales
- El frontend en producción usa URL relativa para consumir `/api`, aprovechando el rewrite configurado en Netlify.
- Se mantiene backend local para desarrollo.
- Se ajustaron mensajes de error de Login y Registro para mostrar errores claros cuando el backend no está disponible.
- Se agregó fallback de CORS en backend si la variable de orígenes permitidos queda vacía.
- Se actualizó `.env.example` con el dominio de producción permitido.