### PR TITLE
Hu-137-Backend: Edición de ofertas académicas

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/academico/malla/repository/MallaMateriaRepository.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/malla/repository/MallaMateriaRepository.java
@@ -11,4 +11,6 @@ public interface MallaMateriaRepository extends JpaRepository<MallaMateria, Long
 	List<MallaMateria> findByMallaIdAndMateriaActiveTrueOrderBySemestreSugeridoAsc(Long mallaId);
 
 	Optional<MallaMateria> findByMallaIdAndMateriaId(Long mallaId, Long materiaId);
+
+	Optional<MallaMateria> findByMallaIdAndMateria_Codigo(Long mallaId, String codigo);
 }

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
@@ -12,7 +12,11 @@ import com.easyschedule.backend.academico.oferta_materia.dto.Importacion.OfertaI
 import com.easyschedule.backend.academico.oferta_materia.service.OfertaMateriaImportService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.ResponseEntity;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
 import java.util.List;
 
 @RestController
@@ -61,5 +65,23 @@ public class OfertaMateriaController {
         @RequestParam("file") MultipartFile file
     ) {
         return ofertaMateriaImportService.importCsv(mallaId, file);
+    }
+
+    @PostMapping("/{id}/validar")
+    public ResponseEntity<Void> validarActualizacion(
+        @PathVariable("id") Long id,
+        @RequestBody OfertaMateriaUpdateRequest request
+    ) {
+        ofertaMateriaService.validarActualizacion(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> actualizarOferta(
+        @PathVariable("id") Long id,
+        @RequestBody OfertaMateriaUpdateRequest request
+    ) {
+        ofertaMateriaService.actualizarOferta(id, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
@@ -1,0 +1,7 @@
+package com.easyschedule.backend.academico.oferta_materia.dto;
+
+public record HorarioDto(
+    String dia,
+    String horaInicio,
+    String horaFin
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaUpdateRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.easyschedule.backend.academico.oferta_materia.dto;
+
+import java.util.List;
+
+public record OfertaMateriaUpdateRequest(
+    String codigoMateria,
+    String nombreMateria,
+    String paralelo,
+    String semestre,
+    String docente,
+    String aula,
+    List<HorarioDto> horarios
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/repository/OfertaMateriaRepository.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/repository/OfertaMateriaRepository.java
@@ -22,6 +22,8 @@ public interface OfertaMateriaRepository extends JpaRepository<OfertaMateria, Lo
         String paralelo
     );
 
+    List<OfertaMateria> findByAulaAndSemestreAndIdNot(String aula, String semestre, Long id);
+
     interface OfertaListRow {
         Long getId();
         String getCodigoMateria();

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
@@ -12,6 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
+import com.easyschedule.backend.academico.oferta_materia.dto.HorarioDto;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -20,15 +25,18 @@ public class OfertaMateriaService {
     private final OfertaMateriaRepository ofertaMateriaRepository;
     private final MallaMateriaRepository mallaMateriaRepository;
     private final PrerequisitoRepository prerequisitoRepository;
+    private final ObjectMapper objectMapper;
 
     public OfertaMateriaService(
         OfertaMateriaRepository ofertaMateriaRepository,
         MallaMateriaRepository mallaMateriaRepository,
-        PrerequisitoRepository prerequisitoRepository
+        PrerequisitoRepository prerequisitoRepository,
+        ObjectMapper objectMapper
     ) {
         this.ofertaMateriaRepository = ofertaMateriaRepository;
         this.mallaMateriaRepository = mallaMateriaRepository;
         this.prerequisitoRepository = prerequisitoRepository;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional(readOnly = true)
@@ -88,6 +96,81 @@ public class OfertaMateriaService {
     @Transactional(readOnly = true)
     public List<String> listarParalelos(Long mallaId) {
         return ofertaMateriaRepository.findDistinctParalelosByMallaId(mallaId);
+    }
+
+    @Transactional(readOnly = true)
+    public void validarActualizacion(Long ofertaId, OfertaMateriaUpdateRequest request) {
+        if (request.aula() == null || request.aula().isBlank()) {
+            return; // If no classroom is assigned, no need to check collisions
+        }
+        
+        List<OfertaMateria> posiblesChoques = ofertaMateriaRepository.findByAulaAndSemestreAndIdNot(
+            request.aula(), request.semestre(), ofertaId
+        );
+        
+        for (OfertaMateria otraOferta : posiblesChoques) {
+            try {
+                List<HorarioDto> otrosHorarios = objectMapper.readValue(
+                    otraOferta.getHorarioJson(), 
+                    new TypeReference<List<HorarioDto>>() {}
+                );
+                
+                for (HorarioDto h1 : request.horarios()) {
+                    for (HorarioDto h2 : otrosHorarios) {
+                        if (h1.dia().equalsIgnoreCase(h2.dia())) {
+                            LocalTime start1 = LocalTime.parse(h1.horaInicio());
+                            LocalTime end1 = LocalTime.parse(h1.horaFin());
+                            LocalTime start2 = LocalTime.parse(h2.horaInicio());
+                            LocalTime end2 = LocalTime.parse(h2.horaFin());
+                            
+                            if (start1.isBefore(end2) && start2.isBefore(end1)) {
+                                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                                    "Choque de horario detectado en el aula " + request.aula() + 
+                                    " el dia " + h1.dia() + " entre " + start1 + " - " + end1);
+                            }
+                        }
+                    }
+                }
+            } catch (ResponseStatusException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error validando horarios");
+            }
+        }
+    }
+
+    @Transactional
+    public void actualizarOferta(Long ofertaId, OfertaMateriaUpdateRequest request) {
+        validarActualizacion(ofertaId, request);
+        
+        OfertaMateria oferta = ofertaMateriaRepository.findById(ofertaId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Oferta no encontrada"));
+            
+        // Handle MallaMateria change if codigoMateria changed
+        MallaMateria currentMm = mallaMateriaRepository.findById(oferta.getMallaMateriaId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MallaMateria actual no encontrada"));
+            
+        if (!currentMm.getMateria().getCodigo().equals(request.codigoMateria())) {
+            MallaMateria newMm = mallaMateriaRepository.findByMallaIdAndMateria_Codigo(
+                currentMm.getMalla().getId(), request.codigoMateria()
+            ).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Materia con codigo " + request.codigoMateria() + " no existe en esta malla"));
+            
+            oferta.setMallaMateriaId(newMm.getId());
+        }
+        
+        oferta.setSemestre(request.semestre());
+        oferta.setParalelo(request.paralelo());
+        oferta.setDocente(request.docente());
+        oferta.setAula(request.aula());
+        
+        try {
+            oferta.setHorarioJson(objectMapper.writeValueAsString(request.horarios()));
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error serializando horario");
+        }
+        
+        oferta.setFechaActualizacion(java.time.OffsetDateTime.now());
+        ofertaMateriaRepository.save(oferta);
     }
 
     private OfertaMateriaResponse toResponse(OfertaMateria o) {

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
@@ -1,30 +1,31 @@
-<div class="confirm-overlay" (click)="onCancel()"></div>
+<div class="confirm-overlay" (click)="onCancel()">
+  <div
+    class="confirm-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="confirm-title"
+    aria-describedby="confirm-message"
+    (click)="$event.stopPropagation()"
+  >
+    <header class="confirm-modal__header">
+      <div>
+        <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
+        <h3 id="confirm-title">{{ title | translate }}</h3>
+      </div>
+      <button #focusTrapStart type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
+    </header>
 
-<div
-  class="confirm-modal"
-  role="dialog"
-  aria-modal="true"
-  aria-labelledby="confirm-title"
-  aria-describedby="confirm-message"
->
-  <header class="confirm-modal__header">
-    <div>
-      <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
-      <h3 id="confirm-title">{{ title | translate }}</h3>
+    <div class="confirm-modal__body">
+      <p id="confirm-message">{{ message | translate }}</p>
     </div>
-    <button #focusTrapStart type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
-  </header>
 
-  <div class="confirm-modal__body">
-    <p id="confirm-message">{{ message | translate }}</p>
+    <footer class="confirm-modal__footer">
+      <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()" [disabled]="processing">
+        {{ cancelLabel | translate }}
+      </button>
+      <button #confirmBtn #focusTrapEnd type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()" [disabled]="processing">
+        {{ confirmLabel | translate }}
+      </button>
+    </footer>
   </div>
-
-  <footer class="confirm-modal__footer">
-    <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()" [disabled]="processing">
-      {{ cancelLabel | translate }}
-    </button>
-    <button #confirmBtn #focusTrapEnd type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()" [disabled]="processing">
-      {{ confirmLabel | translate }}
-    </button>
-  </footer>
 </div>

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
@@ -1,7 +1,7 @@
 .confirm-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: 9999;
   background: rgba(12, 18, 28, 0.54);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

This PR implements the backend support for editing academic offers. It adds the required update request DTOs, validation logic, and endpoints to validate and update an existing `OfertaMateria`.

It also includes an adjustment to the shared confirmation modal so it renders above other modals correctly and remains clickable when used from nested modal flows.

## Changes

- Added `OfertaMateriaUpdateRequest` and `HorarioDto` DTOs for offer update payloads.
- Added endpoint to validate an offer update before saving:
  - `POST /ofertas/{id}/validar`
- Added endpoint to update an existing academic offer:
  - `PUT /ofertas/{id}`
- Added classroom schedule collision validation based on:
  - classroom
  - semester
  - day
  - start/end time overlap
- Added repository support to find:
  - `MallaMateria` by malla ID and subject code
  - other offers in the same classroom and semester excluding the current offer
- Updated offer persistence logic for:
  - subject code changes
  - semester
  - parallel
  - teacher
  - classroom
  - schedule JSON
  - update timestamp
- Fixed the shared confirm modal structure and z-index so it appears centered, clickable, and above other modal overlays.

## Validation behavior

When updating an offer, the backend now checks whether another offer already uses the same classroom during an overlapping schedule block. If a collision is detected, the API returns a `400 BAD_REQUEST` with a descriptive message.

## Tests
<img width="1504" height="495" alt="image" src="https://github.com/user-attachments/assets/01dd044c-592b-4004-a81c-9b706b1bab39" />
