### PR TITLE
HU-139-Frontend: Edición de ofertas académicas

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/academico/horario/service/HorarioGeneradorService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/horario/service/HorarioGeneradorService.java
@@ -351,9 +351,11 @@ public class HorarioGeneradorService {
                 String dia = text(slot, "dia");
                 String horaInicioStr = text(slot, "inicio");
                 if (horaInicioStr == null) horaInicioStr = text(slot, "hora_inicio");
+                if (horaInicioStr == null) horaInicioStr = text(slot, "horaInicio");
 
                 String horaFinStr = text(slot, "fin");
                 if (horaFinStr == null) horaFinStr = text(slot, "hora_fin");
+                if (horaFinStr == null) horaFinStr = text(slot, "horaFin");
 
                 if (dia != null && horaInicioStr != null && horaFinStr != null) {
                     bloques.add(new ClaseBloqueDTO(

--- a/backend/src/main/java/com/easyschedule/backend/academico/malla/repository/MallaMateriaRepository.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/malla/repository/MallaMateriaRepository.java
@@ -11,4 +11,6 @@ public interface MallaMateriaRepository extends JpaRepository<MallaMateria, Long
 	List<MallaMateria> findByMallaIdAndMateriaActiveTrueOrderBySemestreSugeridoAsc(Long mallaId);
 
 	Optional<MallaMateria> findByMallaIdAndMateriaId(Long mallaId, Long materiaId);
+
+	Optional<MallaMateria> findByMallaIdAndMateria_Codigo(Long mallaId, String codigo);
 }

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
@@ -5,18 +5,19 @@ import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaListRe
 import com.easyschedule.backend.academico.oferta_materia.service.OfertaMateriaService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.easyschedule.backend.academico.oferta_materia.dto.Importacion.OfertaImportResultResponse;
 import com.easyschedule.backend.academico.oferta_materia.service.OfertaMateriaImportService;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.http.ResponseEntity;
 import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaEdicionResponse;
 import java.util.List;
 
 @RestController
@@ -37,6 +38,11 @@ public class OfertaMateriaController {
     @GetMapping("/detalles/{mallaMateriaId}")
     public OfertaDetalleResponse getDetallesMateria(@PathVariable("mallaMateriaId") Long mallaMateriaId) {
         return ofertaMateriaService.getDetalleParaInscripcion(mallaMateriaId);
+    }
+
+    @GetMapping("/{id}/edicion")
+    public OfertaMateriaEdicionResponse obtenerParaEdicion(@PathVariable("id") Long id) {
+        return ofertaMateriaService.obtenerParaEdicion(id);
     }
 
     @GetMapping("/listar")

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/controller/OfertaMateriaController.java
@@ -12,7 +12,11 @@ import com.easyschedule.backend.academico.oferta_materia.dto.Importacion.OfertaI
 import com.easyschedule.backend.academico.oferta_materia.service.OfertaMateriaImportService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.ResponseEntity;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
 import java.util.List;
 
 @RestController
@@ -61,5 +65,23 @@ public class OfertaMateriaController {
         @RequestParam("file") MultipartFile file
     ) {
         return ofertaMateriaImportService.importCsv(mallaId, file);
+    }
+
+    @PostMapping("/{id}/validar")
+    public ResponseEntity<Void> validarActualizacion(
+        @PathVariable("id") Long id,
+        @RequestBody OfertaMateriaUpdateRequest request
+    ) {
+        ofertaMateriaService.validarActualizacion(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> actualizarOferta(
+        @PathVariable("id") Long id,
+        @RequestBody OfertaMateriaUpdateRequest request
+    ) {
+        ofertaMateriaService.actualizarOferta(id, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
@@ -1,7 +1,16 @@
 package com.easyschedule.backend.academico.oferta_materia.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record HorarioDto(
     String dia,
+    
+    @JsonAlias({"inicio", "horaInicio"})
+    @JsonProperty("horaInicio")
     String horaInicio,
+    
+    @JsonAlias({"fin", "horaFin"})
+    @JsonProperty("horaFin")
     String horaFin
 ) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/HorarioDto.java
@@ -1,0 +1,7 @@
+package com.easyschedule.backend.academico.oferta_materia.dto;
+
+public record HorarioDto(
+    String dia,
+    String horaInicio,
+    String horaFin
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaEdicionResponse.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaEdicionResponse.java
@@ -1,0 +1,14 @@
+package com.easyschedule.backend.academico.oferta_materia.dto;
+
+import java.util.List;
+
+public record OfertaMateriaEdicionResponse(
+    Long id,
+    String codigoMateria,
+    String nombreMateria,
+    String paralelo,
+    String semestre,
+    String docente,
+    String aula,
+    List<HorarioDto> horarios
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaUpdateRequest.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/dto/OfertaMateriaUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.easyschedule.backend.academico.oferta_materia.dto;
+
+import java.util.List;
+
+public record OfertaMateriaUpdateRequest(
+    String codigoMateria,
+    String nombreMateria,
+    String paralelo,
+    String semestre,
+    String docente,
+    String aula,
+    List<HorarioDto> horarios
+) {}

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/repository/OfertaMateriaRepository.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/repository/OfertaMateriaRepository.java
@@ -22,6 +22,8 @@ public interface OfertaMateriaRepository extends JpaRepository<OfertaMateria, Lo
         String paralelo
     );
 
+    List<OfertaMateria> findByAulaAndSemestreAndIdNot(String aula, String semestre, Long id);
+
     interface OfertaListRow {
         Long getId();
         String getCodigoMateria();

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaImportService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaImportService.java
@@ -728,8 +728,8 @@ public class OfertaMateriaImportService {
 
     private record HorarioJsonBlock(
         String dia,
-        String inicio,
-        String fin
+        String horaInicio,
+        String horaFin
     ) {
     }
 

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
@@ -15,6 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaEdicionResponse;
 import com.easyschedule.backend.academico.oferta_materia.dto.HorarioDto;
 import java.time.LocalTime;
 import java.util.List;
@@ -91,6 +92,33 @@ public class OfertaMateriaService {
     @Transactional(readOnly = true)
     public List<String> listarSemestres(Long mallaId) {
         return ofertaMateriaRepository.findDistinctSemestresByMallaId(mallaId);
+    }
+
+    @Transactional(readOnly = true)
+    public OfertaMateriaEdicionResponse obtenerParaEdicion(Long id) {
+        OfertaMateria oferta = ofertaMateriaRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Oferta no encontrada"));
+            
+        MallaMateria mm = mallaMateriaRepository.findById(oferta.getMallaMateriaId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MallaMateria no encontrada"));
+            
+        List<HorarioDto> horarios;
+        try {
+            horarios = objectMapper.readValue(oferta.getHorarioJson(), new TypeReference<List<HorarioDto>>() {});
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error deserializando horarios");
+        }
+        
+        return new OfertaMateriaEdicionResponse(
+            oferta.getId(),
+            mm.getMateria().getCodigo(),
+            mm.getMateria().getNombre(),
+            oferta.getParalelo(),
+            oferta.getSemestre(),
+            oferta.getDocente(),
+            oferta.getAula(),
+            horarios
+        );
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaService.java
@@ -12,6 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
+import com.easyschedule.backend.academico.oferta_materia.dto.HorarioDto;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -20,15 +25,18 @@ public class OfertaMateriaService {
     private final OfertaMateriaRepository ofertaMateriaRepository;
     private final MallaMateriaRepository mallaMateriaRepository;
     private final PrerequisitoRepository prerequisitoRepository;
+    private final ObjectMapper objectMapper;
 
     public OfertaMateriaService(
         OfertaMateriaRepository ofertaMateriaRepository,
         MallaMateriaRepository mallaMateriaRepository,
-        PrerequisitoRepository prerequisitoRepository
+        PrerequisitoRepository prerequisitoRepository,
+        ObjectMapper objectMapper
     ) {
         this.ofertaMateriaRepository = ofertaMateriaRepository;
         this.mallaMateriaRepository = mallaMateriaRepository;
         this.prerequisitoRepository = prerequisitoRepository;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional(readOnly = true)
@@ -88,6 +96,81 @@ public class OfertaMateriaService {
     @Transactional(readOnly = true)
     public List<String> listarParalelos(Long mallaId) {
         return ofertaMateriaRepository.findDistinctParalelosByMallaId(mallaId);
+    }
+
+    @Transactional(readOnly = true)
+    public void validarActualizacion(Long ofertaId, OfertaMateriaUpdateRequest request) {
+        if (request.aula() == null || request.aula().isBlank()) {
+            return; // If no classroom is assigned, no need to check collisions
+        }
+        
+        List<OfertaMateria> posiblesChoques = ofertaMateriaRepository.findByAulaAndSemestreAndIdNot(
+            request.aula(), request.semestre(), ofertaId
+        );
+        
+        for (OfertaMateria otraOferta : posiblesChoques) {
+            try {
+                List<HorarioDto> otrosHorarios = objectMapper.readValue(
+                    otraOferta.getHorarioJson(), 
+                    new TypeReference<List<HorarioDto>>() {}
+                );
+                
+                for (HorarioDto h1 : request.horarios()) {
+                    for (HorarioDto h2 : otrosHorarios) {
+                        if (h1.dia().equalsIgnoreCase(h2.dia())) {
+                            LocalTime start1 = LocalTime.parse(h1.horaInicio());
+                            LocalTime end1 = LocalTime.parse(h1.horaFin());
+                            LocalTime start2 = LocalTime.parse(h2.horaInicio());
+                            LocalTime end2 = LocalTime.parse(h2.horaFin());
+                            
+                            if (start1.isBefore(end2) && start2.isBefore(end1)) {
+                                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                                    "Choque de horario detectado en el aula " + request.aula() + 
+                                    " el dia " + h1.dia() + " entre " + start1 + " - " + end1);
+                            }
+                        }
+                    }
+                }
+            } catch (ResponseStatusException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error validando horarios");
+            }
+        }
+    }
+
+    @Transactional
+    public void actualizarOferta(Long ofertaId, OfertaMateriaUpdateRequest request) {
+        validarActualizacion(ofertaId, request);
+        
+        OfertaMateria oferta = ofertaMateriaRepository.findById(ofertaId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Oferta no encontrada"));
+            
+        // Handle MallaMateria change if codigoMateria changed
+        MallaMateria currentMm = mallaMateriaRepository.findById(oferta.getMallaMateriaId())
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "MallaMateria actual no encontrada"));
+            
+        if (!currentMm.getMateria().getCodigo().equals(request.codigoMateria())) {
+            MallaMateria newMm = mallaMateriaRepository.findByMallaIdAndMateria_Codigo(
+                currentMm.getMalla().getId(), request.codigoMateria()
+            ).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Materia con codigo " + request.codigoMateria() + " no existe en esta malla"));
+            
+            oferta.setMallaMateriaId(newMm.getId());
+        }
+        
+        oferta.setSemestre(request.semestre());
+        oferta.setParalelo(request.paralelo());
+        oferta.setDocente(request.docente());
+        oferta.setAula(request.aula());
+        
+        try {
+            oferta.setHorarioJson(objectMapper.writeValueAsString(request.horarios()));
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error serializando horario");
+        }
+        
+        oferta.setFechaActualizacion(java.time.OffsetDateTime.now());
+        ofertaMateriaRepository.save(oferta);
     }
 
     private OfertaMateriaResponse toResponse(OfertaMateria o) {

--- a/backend/src/test/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaImportServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaImportServiceTest.java
@@ -98,8 +98,8 @@ class OfertaMateriaImportServiceTest {
         assertThat(saved.getFechaActualizacion()).isNotNull();
         assertThat(saved.getHorarioJson()).contains("\"dia\":\"Lunes\"");
         assertThat(saved.getHorarioJson()).contains("\"dia\":\"Miercoles\"");
-        assertThat(saved.getHorarioJson()).contains("\"inicio\":\"08:00\"");
-        assertThat(saved.getHorarioJson()).contains("\"fin\":\"09:30\"");
+        assertThat(saved.getHorarioJson()).contains("\"horaInicio\":\"08:00\"");
+        assertThat(saved.getHorarioJson()).contains("\"horaFin\":\"09:30\"");
     }
 
     @Test
@@ -136,8 +136,8 @@ class OfertaMateriaImportServiceTest {
         assertThat(existingOffer.getDocente()).isEqualTo("Ing. Valeria Alvarez");
         assertThat(existingOffer.getAula()).isEqualTo("LAB-306");
         assertThat(existingOffer.getHorarioJson()).contains("\"dia\":\"Viernes\"");
-        assertThat(existingOffer.getHorarioJson()).contains("\"inicio\":\"10:00\"");
-        assertThat(existingOffer.getHorarioJson()).contains("\"fin\":\"12:00\"");
+        assertThat(existingOffer.getHorarioJson()).contains("\"horaInicio\":\"10:00\"");
+        assertThat(existingOffer.getHorarioJson()).contains("\"horaFin\":\"12:00\"");
         assertThat(existingOffer.getFechaActualizacion()).isNotNull();
     }
 

--- a/backend/src/test/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/academico/oferta_materia/service/OfertaMateriaServiceTest.java
@@ -1,0 +1,167 @@
+package com.easyschedule.backend.academico.oferta_materia.service;
+
+import com.easyschedule.backend.academico.malla.model.MallaMateria;
+import com.easyschedule.backend.academico.malla.repository.MallaMateriaRepository;
+import com.easyschedule.backend.academico.materia.model.Materia;
+import com.easyschedule.backend.academico.materia.repository.PrerequisitoRepository;
+import com.easyschedule.backend.academico.oferta_materia.dto.HorarioDto;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaEdicionResponse;
+import com.easyschedule.backend.academico.oferta_materia.dto.OfertaMateriaUpdateRequest;
+import com.easyschedule.backend.academico.oferta_materia.model.OfertaMateria;
+import com.easyschedule.backend.academico.oferta_materia.repository.OfertaMateriaRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OfertaMateriaServiceTest {
+
+    @Mock
+    private OfertaMateriaRepository ofertaMateriaRepository;
+
+    @Mock
+    private MallaMateriaRepository mallaMateriaRepository;
+
+    @Mock
+    private PrerequisitoRepository prerequisitoRepository;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private OfertaMateriaService ofertaMateriaService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        
+        ofertaMateriaService = new OfertaMateriaService(
+                ofertaMateriaRepository,
+                mallaMateriaRepository,
+                prerequisitoRepository,
+                objectMapper
+        );
+    }
+
+    @Test
+    void obtenerParaEdicion_DebeRetornarOfertaMapeada() throws Exception {
+        OfertaMateria oferta = new OfertaMateria();
+        oferta.setId(1L);
+        oferta.setMallaMateriaId(100L);
+        oferta.setParalelo("A");
+        oferta.setSemestre("1");
+        oferta.setDocente("Juan Perez");
+        oferta.setAula("Aula 1");
+        oferta.setHorarioJson("[{\"dia\":\"Lunes\",\"inicio\":\"08:00\",\"fin\":\"09:30\"}]");
+
+        MallaMateria mallaMateria = new MallaMateria();
+        mallaMateria.setId(100L);
+
+        Materia materia = new Materia();
+        materia.setId(200L);
+        materia.setCodigo("MAT-101");
+        materia.setNombre("Matematicas");
+        
+        mallaMateria.setMateria(materia);
+
+        when(ofertaMateriaRepository.findById(1L)).thenReturn(Optional.of(oferta));
+        when(mallaMateriaRepository.findById(100L)).thenReturn(Optional.of(mallaMateria));
+
+        OfertaMateriaEdicionResponse response = ofertaMateriaService.obtenerParaEdicion(1L);
+
+        assertThat(response).isNotNull();
+        assertThat(response.codigoMateria()).isEqualTo("MAT-101");
+        assertThat(response.nombreMateria()).isEqualTo("Matematicas");
+        assertThat(response.docente()).isEqualTo("Juan Perez");
+        assertThat(response.horarios()).hasSize(1);
+        assertThat(response.horarios().get(0).horaInicio()).isEqualTo("08:00");
+    }
+
+    @Test
+    void validarActualizacion_SinCruces_PasaSinExcepcion() {
+        OfertaMateriaUpdateRequest request = new OfertaMateriaUpdateRequest(
+                "MAT-101", "Matematicas", "A", "1", "Juan Perez", "Aula 1",
+                List.of(new HorarioDto("Lunes", "08:00", "09:30"))
+        );
+
+        when(ofertaMateriaRepository.findByAulaAndSemestreAndIdNot("Aula 1", "1", 1L)).thenReturn(List.of());
+
+        ofertaMateriaService.validarActualizacion(1L, request);
+    }
+
+    @Test
+    void validarActualizacion_DiferenteAula_PasaSinExcepcion() {
+        OfertaMateriaUpdateRequest request = new OfertaMateriaUpdateRequest(
+                "MAT-101", "Matematicas", "A", "1", "Juan Perez", "Aula 1",
+                List.of(new HorarioDto("Lunes", "08:00", "09:30"))
+        );
+
+        when(ofertaMateriaRepository.findByAulaAndSemestreAndIdNot("Aula 1", "1", 1L)).thenReturn(List.of());
+
+        ofertaMateriaService.validarActualizacion(1L, request);
+    }
+
+    @Test
+    void validarActualizacion_ConCruceHorarioMismaAula_LanzaExcepcion() {
+        OfertaMateria otraOferta = new OfertaMateria();
+        otraOferta.setId(2L);
+        otraOferta.setSemestre("1");
+        otraOferta.setAula("Aula 1");
+        otraOferta.setHorarioJson("[{\"dia\":\"Lunes\",\"horaInicio\":\"08:00\",\"horaFin\":\"10:00\"}]");
+
+        OfertaMateriaUpdateRequest request = new OfertaMateriaUpdateRequest(
+                "MAT-101", "Matematicas", "A", "1", "Juan Perez", "Aula 1",
+                List.of(new HorarioDto("Lunes", "09:00", "11:00"))
+        );
+
+        when(ofertaMateriaRepository.findByAulaAndSemestreAndIdNot("Aula 1", "1", 1L)).thenReturn(List.of(otraOferta));
+
+        assertThatThrownBy(() -> ofertaMateriaService.validarActualizacion(1L, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Choque de horario detectado en el aula Aula 1");
+    }
+
+    @Test
+    void actualizarOferta_DatosValidos_GuardaCorrectamente() throws Exception {
+        OfertaMateria oferta = new OfertaMateria();
+        oferta.setId(1L);
+        oferta.setMallaMateriaId(100L);
+        oferta.setSemestre("1");
+
+        Materia materia = new Materia();
+        materia.setId(200L);
+        materia.setCodigo("MAT-101");
+
+        MallaMateria mallaMateria = new MallaMateria();
+        mallaMateria.setId(100L);
+        mallaMateria.setMateria(materia);
+
+        OfertaMateriaUpdateRequest request = new OfertaMateriaUpdateRequest(
+                "MAT-101", "Matematicas", "B", "1", "Maria Lopez", "Aula 5",
+                List.of(new HorarioDto("Martes", "10:00", "12:00"))
+        );
+
+        when(ofertaMateriaRepository.findById(1L)).thenReturn(Optional.of(oferta));
+        when(ofertaMateriaRepository.findByAulaAndSemestreAndIdNot("Aula 5", "1", 1L)).thenReturn(List.of());
+        when(mallaMateriaRepository.findById(100L)).thenReturn(Optional.of(mallaMateria));
+
+        ofertaMateriaService.actualizarOferta(1L, request);
+
+        verify(ofertaMateriaRepository).save(oferta);
+        assertThat(oferta.getParalelo()).isEqualTo("B");
+        assertThat(oferta.getDocente()).isEqualTo("Maria Lopez");
+        assertThat(oferta.getAula()).isEqualTo("Aula 5");
+        assertThat(oferta.getHorarioJson()).contains("horaInicio");
+    }
+}

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.html
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.html
@@ -87,6 +87,7 @@
               <th>{{ 'malla.manageOffers.colParalelo' | translate }}</th>
               <th>{{ 'malla.manageOffers.colDocente' | translate }}</th>
               <th>{{ 'malla.manageOffers.colAula' | translate }}</th>
+              <th>Acciones</th>
             </tr>
           </thead>
           <tbody>
@@ -97,6 +98,11 @@
               <td>{{ o.paralelo }}</td>
               <td>{{ o.docente }}</td>
               <td>{{ o.aula }}</td>
+              <td>
+                <button type="button" class="go-button go-button--ghost" (click)="abrirEdicion(o.id)">
+                  Editar
+                </button>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -110,3 +116,77 @@
     </button>
   </footer>
 </section>
+
+<!-- Edit Modal Overlay -->
+<div class="go-edit-backdrop" *ngIf="editingOferta" (click)="cerrarEdicion()"></div>
+<section class="go-edit-modal" *ngIf="editingOferta" role="dialog" aria-modal="true">
+  <header class="go-modal__header">
+    <div>
+      <p class="go-modal__eyebrow">Edición</p>
+      <h2>Editar Oferta</h2>
+    </div>
+    <button type="button" class="go-modal__close" (click)="cerrarEdicion()">×</button>
+  </header>
+
+  <div class="go-modal__body">
+    <div class="go-edit-form">
+      <div class="go-filters__group">
+        <label class="go-filters__label">Código de Materia</label>
+        <input class="go-input" type="text" [(ngModel)]="editingOferta.codigoMateria" />
+      </div>
+      <div class="go-filters__group">
+        <label class="go-filters__label">Semestre Académico</label>
+        <input class="go-input" type="text" [(ngModel)]="editingOferta.semestre" />
+      </div>
+      <div class="go-filters__group">
+        <label class="go-filters__label">Paralelo</label>
+        <input class="go-input" type="text" [(ngModel)]="editingOferta.paralelo" />
+      </div>
+      <div class="go-filters__group">
+        <label class="go-filters__label">Docente</label>
+        <input class="go-input" type="text" [(ngModel)]="editingOferta.docente" />
+      </div>
+      <div class="go-filters__group">
+        <label class="go-filters__label">Aula</label>
+        <input class="go-input" type="text" [(ngModel)]="editingOferta.aula" />
+      </div>
+
+      <div class="go-edit-horarios">
+        <h3>Horarios</h3>
+        <div class="go-horario-row" *ngFor="let h of editingOferta.horarios; let i = index">
+          <select class="go-input go-input--select" [(ngModel)]="h.dia">
+            <option value="LUNES">LUNES</option>
+            <option value="MARTES">MARTES</option>
+            <option value="MIERCOLES">MIERCOLES</option>
+            <option value="JUEVES">JUEVES</option>
+            <option value="VIERNES">VIERNES</option>
+            <option value="SABADO">SABADO</option>
+            <option value="DOMINGO">DOMINGO</option>
+          </select>
+          <input class="go-input" type="time" [(ngModel)]="h.horaInicio" />
+          <input class="go-input" type="time" [(ngModel)]="h.horaFin" />
+          <button type="button" class="go-button go-button--ghost" (click)="removeHorarioBlock(i)">X</button>
+        </div>
+        <button type="button" class="go-button go-button--ghost" (click)="addHorarioBlock()">+ Añadir Bloque</button>
+      </div>
+      
+      <div class="go-messages">
+        <div *ngIf="editErrorMsg" class="go-message-error">{{ editErrorMsg }}</div>
+        <div *ngIf="editSuccessMsg" class="go-message-success">{{ editSuccessMsg }}</div>
+      </div>
+    </div>
+  </div>
+
+  <footer class="go-modal__footer">
+    <button type="button" class="go-button go-button--ghost" (click)="cerrarEdicion()">Cancelar</button>
+    <button type="button" class="go-button go-button--ghost" [disabled]="isValidating || isSaving" (click)="validarEdicion()">
+      <span *ngIf="isValidating">Validando...</span>
+      <span *ngIf="!isValidating">Validar</span>
+    </button>
+    <button type="button" class="go-button" [disabled]="isValidating || isSaving" (click)="guardarEdicion()">
+      <span *ngIf="isSaving">Guardando...</span>
+      <span *ngIf="!isSaving">Guardar</span>
+    </button>
+  </footer>
+</section>
+

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.scss
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.scss
@@ -223,7 +223,274 @@
     flex-direction: column;
   }
 
+  h2 {
+    margin: 0;
+    color: var(--color-blue-dark);
+    font-family: 'Poppins', sans-serif;
+  }
+}
+
+.go-modal__eyebrow {
+  margin: 0 0 0.25rem;
+  color: #3f6383;
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.go-modal__close {
+  width: 36px;
+  height: 36px;
+  border: 1px solid rgba(47, 79, 115, 0.24);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-blue-dark);
+  font-size: 1.45rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.go-modal__body {
+  overflow: auto;
+  padding: 1.2rem 1.4rem;
+}
+
+.go-filters {
+  margin-bottom: 1rem;
+  border: 1px solid rgba(47, 79, 115, 0.18);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.72);
+  padding: 1rem;
+}
+
+.go-filters__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.go-filters__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 160px;
+  flex: 1;
+}
+
+.go-filters__label {
+  color: var(--color-blue-dark);
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.go-input {
+  border: 1px solid rgba(47, 79, 115, 0.24);
+  border-radius: 10px;
+  background: #fff;
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  color: #2b3442;
+  outline: none;
+
+  &:focus {
+    border-color: var(--color-blue-dark);
+  }
+}
+
+.go-input--select {
+  cursor: pointer;
+}
+
+.go-filters__actions {
+  display: flex;
+  align-items: flex-end;
+  padding-bottom: 1px;
+}
+
+.go-loading {
+  padding: 2rem 0;
+  text-align: center;
+  color: #3f6383;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.go-empty {
+  padding: 2rem 0;
+  text-align: center;
+  color: rgba(18, 23, 34, 0.72);
+  font-style: italic;
+}
+
+.go-table-wrap {
+  overflow-x: auto;
+}
+
+.go-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    color: var(--color-blue-dark);
+    font-family: 'Poppins', sans-serif;
+    font-size: 0.82rem;
+    font-weight: 700;
+    border-bottom: 2px solid rgba(47, 79, 115, 0.18);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 0.55rem 0.75rem;
+    border-bottom: 1px solid rgba(47, 79, 115, 0.1);
+    font-size: 0.9rem;
+    color: #2b3442;
+  }
+
+  tbody tr:hover {
+    background: rgba(47, 79, 115, 0.04);
+  }
+}
+
+.go-table__code {
+  font-family: Consolas, 'Courier New', monospace;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.go-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.4rem;
+  border-top: 1px solid rgba(47, 79, 115, 0.18);
+  background: #f7f3e7;
+}
+
+.go-button {
+  border: 0;
+  border-radius: 10px;
+  background: var(--color-blue-dark);
+  color: #fff;
+  padding: 0.55rem 1rem;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 700;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+}
+
+.go-button--ghost {
+  border: 1px solid rgba(47, 79, 115, 0.24);
+  background: transparent;
+  color: var(--color-blue-dark);
+}
+
+@media (max-width: 720px) {
+  .go-modal {
+    inset: 2vh 50%;
+    width: 96vw;
+    max-height: 96vh;
+  }
+
+  .go-modal__header,
+  .go-modal__footer {
+    padding: 1rem;
+  }
+
+  .go-modal__body {
+    padding: 1rem;
+  }
+
+  .go-modal__footer {
+    flex-direction: column;
+  }
+
+  .go-filters__row {
+    flex-direction: column;
+  }
+
   .go-button {
     width: 100%;
   }
+}
+
+.go-edit-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(18, 23, 34, 0.42);
+}
+
+.go-edit-modal {
+  position: fixed;
+  inset: 4vh 50%;
+  z-index: 2001;
+  width: min(720px, 94vw);
+  max-height: 92vh;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  border-radius: 18px;
+  border: 1px solid rgba(47, 79, 115, 0.24);
+  background: #f7f3e7;
+  box-shadow: 0 18px 48px rgba(17, 24, 39, 0.24);
+  overflow: hidden;
+}
+
+.go-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.go-edit-horarios {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(47, 79, 115, 0.18);
+
+  h3 {
+    margin: 0 0 1rem;
+    color: var(--color-blue-dark);
+    font-family: 'Poppins', sans-serif;
+  }
+}
+
+.go-horario-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  align-items: center;
+
+  .go-input {
+    flex: 1;
+  }
+}
+
+.go-messages {
+  margin-top: 1rem;
+}
+
+.go-message-error {
+  color: #d32f2f;
+  background: #ffebee;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.go-message-success {
+  color: #2e7d32;
+  background: #e8f5e9;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
 }

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.spec.ts
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.spec.ts
@@ -1,0 +1,161 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GestionarOfertas } from './gestionar-ofertas';
+import { OfertaImportService } from '../../../services/academico/oferta-import.service';
+import { of, throwError } from 'rxjs';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('GestionarOfertas', () => {
+  let component: GestionarOfertas;
+  let fixture: ComponentFixture<GestionarOfertas>;
+  let mockOfertaImportService: jasmine.SpyObj<OfertaImportService>;
+
+  beforeEach(async () => {
+    mockOfertaImportService = jasmine.createSpyObj('OfertaImportService', [
+      'listarSemestres',
+      'listarParalelos',
+      'listarOfertas',
+      'obtenerOfertaParaEdicion',
+      'validarActualizacion',
+      'actualizarOferta'
+    ]);
+
+    // Setup default mock returns
+    mockOfertaImportService.listarSemestres.and.returnValue(of(['1', '2']));
+    mockOfertaImportService.listarParalelos.and.returnValue(of(['A', 'B']));
+    mockOfertaImportService.listarOfertas.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [GestionarOfertas, FormsModule, TranslateModule.forRoot()],
+      providers: [
+        { provide: OfertaImportService, useValue: mockOfertaImportService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GestionarOfertas);
+    component = fixture.componentInstance;
+    component.mallaId = 1;
+    fixture.detectChanges();
+  });
+
+  it('debe crearse correctamente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('abrirEdicion', () => {
+    it('debe mapear el dia a mayusculas', async () => {
+      // Arrange
+      const mockOferta = {
+        id: 1,
+        codigoMateria: 'MAT-101',
+        nombreMateria: 'Matematicas',
+        paralelo: 'A',
+        semestre: '1',
+        docente: 'Docente X',
+        aula: 'Aula 1',
+        horarios: [{ dia: 'Lunes', horaInicio: '08:00', horaFin: '09:30' }]
+      };
+      mockOfertaImportService.obtenerOfertaParaEdicion.and.returnValue(of(mockOferta));
+
+      // Act
+      await component['abrirEdicion'](1);
+
+      // Assert
+      expect(component['editingOferta']).toBeTruthy();
+      expect(component['editingOferta']?.horarios[0].dia).toBe('LUNES');
+    });
+  });
+
+  describe('gestionar bloques de horario', () => {
+    beforeEach(() => {
+      component['editingOferta'] = {
+        id: 1,
+        codigoMateria: 'MAT-101',
+        nombreMateria: 'Matematicas',
+        paralelo: 'A',
+        semestre: '1',
+        docente: 'Docente X',
+        aula: 'Aula 1',
+        horarios: []
+      };
+    });
+
+    it('addHorarioBlock debe agregar un bloque por defecto', () => {
+      component['addHorarioBlock']();
+      expect(component['editingOferta']?.horarios.length).toBe(1);
+      expect(component['editingOferta']?.horarios[0].dia).toBe('LUNES');
+    });
+
+    it('removeHorarioBlock debe eliminar el bloque en el indice especificado', () => {
+      component['addHorarioBlock']();
+      component['addHorarioBlock'](); // 2 blocks
+      component['removeHorarioBlock'](0);
+      expect(component['editingOferta']?.horarios.length).toBe(1);
+    });
+  });
+
+  describe('validarEdicion', () => {
+    beforeEach(() => {
+      component['editingOferta'] = {
+        id: 1,
+        codigoMateria: 'MAT-101',
+        nombreMateria: 'Matematicas',
+        paralelo: 'A',
+        semestre: '1',
+        docente: 'Docente X',
+        aula: 'Aula 1',
+        horarios: []
+      };
+    });
+
+    it('debe mostrar mensaje de exito si la validacion pasa', async () => {
+      mockOfertaImportService.validarActualizacion.and.returnValue(of(undefined)); // Success
+      await component['validarEdicion']();
+      expect(component['editSuccessMsg']).toContain('exitosa');
+      expect(component['editErrorMsg']).toBe('');
+    });
+
+    it('debe mostrar mensaje de error si hay cruce', async () => {
+      const errorResponse = { error: { message: 'Cruce de horario en Aula 1' } };
+      mockOfertaImportService.validarActualizacion.and.returnValue(throwError(() => errorResponse));
+      await component['validarEdicion']();
+      expect(component['editErrorMsg']).toBe('Cruce de horario en Aula 1');
+      expect(component['editSuccessMsg']).toBe('');
+    });
+  });
+
+  describe('guardarEdicion', () => {
+    beforeEach(() => {
+      component['editingOferta'] = {
+        id: 1,
+        codigoMateria: 'MAT-101',
+        nombreMateria: 'Matematicas',
+        paralelo: 'A',
+        semestre: '1',
+        docente: 'Docente X',
+        aula: 'Aula 1',
+        horarios: []
+      };
+    });
+
+    it('debe cerrar la edicion y recargar si guarda con exito', async () => {
+      mockOfertaImportService.actualizarOferta.and.returnValue(of(undefined));
+      spyOn<any>(component, 'loadOfertas');
+      
+      await component['guardarEdicion']();
+      
+      expect(component['editingOferta']).toBeNull(); // Cerrar edicion
+      expect(component['loadOfertas']).toHaveBeenCalled(); // Recargar
+    });
+
+    it('debe mostrar error si falla el guardado', async () => {
+      const errorResponse = { error: { message: 'Error de servidor' } };
+      mockOfertaImportService.actualizarOferta.and.returnValue(throwError(() => errorResponse));
+      
+      await component['guardarEdicion']();
+      
+      expect(component['editErrorMsg']).toBe('Error de servidor');
+      expect(component['editingOferta']).not.toBeNull(); // No se cierra
+    });
+  });
+});

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
@@ -4,7 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 
-import { OfertaImportService, OfertaListResponse } from '../../../services/academico/oferta-import.service';
+import { 
+  OfertaImportService, 
+  OfertaListResponse, 
+  OfertaMateriaEdicionResponse, 
+  OfertaMateriaUpdateRequest 
+} from '../../../services/academico/oferta-import.service';
 
 @Component({
   selector: 'app-gestionar-ofertas',
@@ -25,6 +30,12 @@ export class GestionarOfertas implements OnInit {
   protected searchTerm = '';
   protected selectedSemestre = '';
   protected selectedParalelo = '';
+
+  protected editingOferta: OfertaMateriaEdicionResponse | null = null;
+  protected editErrorMsg = '';
+  protected editSuccessMsg = '';
+  protected isValidating = false;
+  protected isSaving = false;
 
   constructor(private readonly ofertaImportService: OfertaImportService) {}
 
@@ -86,6 +97,95 @@ export class GestionarOfertas implements OnInit {
       this.loaded = true;
     } finally {
       this.loading = false;
+    }
+  }
+
+  protected async abrirEdicion(id: number): Promise<void> {
+    try {
+      this.editingOferta = await firstValueFrom(this.ofertaImportService.obtenerOfertaParaEdicion(id));
+      if (this.editingOferta && this.editingOferta.horarios) {
+        this.editingOferta.horarios.forEach(h => {
+          if (h.dia) {
+            h.dia = h.dia.toUpperCase();
+          }
+        });
+      }
+      this.editErrorMsg = '';
+      this.editSuccessMsg = '';
+    } catch {
+      alert('Error al obtener la oferta para edición.');
+    }
+  }
+
+  protected cerrarEdicion(): void {
+    this.editingOferta = null;
+  }
+
+  protected addHorarioBlock(): void {
+    if (this.editingOferta) {
+      this.editingOferta.horarios.push({
+        dia: 'LUNES',
+        horaInicio: '08:15',
+        horaFin: '09:45'
+      });
+    }
+  }
+
+  protected removeHorarioBlock(index: number): void {
+    if (this.editingOferta) {
+      this.editingOferta.horarios.splice(index, 1);
+    }
+  }
+
+  private buildUpdateRequest(): OfertaMateriaUpdateRequest {
+    if (!this.editingOferta) throw new Error('No editing oferta');
+    return {
+      codigoMateria: this.editingOferta.codigoMateria || '',
+      nombreMateria: this.editingOferta.nombreMateria || '',
+      paralelo: this.editingOferta.paralelo || '',
+      semestre: this.editingOferta.semestre || '',
+      docente: this.editingOferta.docente || '',
+      aula: this.editingOferta.aula || '',
+      horarios: this.editingOferta.horarios || []
+    };
+  }
+
+  protected async validarEdicion(): Promise<void> {
+    if (!this.editingOferta) return;
+    this.isValidating = true;
+    this.editErrorMsg = '';
+    this.editSuccessMsg = '';
+    
+    try {
+      await firstValueFrom(this.ofertaImportService.validarActualizacion(
+        this.editingOferta.id, 
+        this.buildUpdateRequest()
+      ));
+      this.editSuccessMsg = '¡Validación exitosa! No se detectaron cruces de horario.';
+    } catch (e: any) {
+      this.editErrorMsg = e.error?.message || 'Error durante la validación.';
+    } finally {
+      this.isValidating = false;
+    }
+  }
+
+  protected async guardarEdicion(): Promise<void> {
+    if (!this.editingOferta) return;
+    this.isSaving = true;
+    this.editErrorMsg = '';
+    this.editSuccessMsg = '';
+    
+    try {
+      await firstValueFrom(this.ofertaImportService.actualizarOferta(
+        this.editingOferta.id, 
+        this.buildUpdateRequest()
+      ));
+      this.cerrarEdicion();
+      await this.loadOfertas();
+    } catch (e: any) {
+      this.editErrorMsg = e.error?.message || 'Error al guardar la oferta.';
+    } finally {
+      this.isSaving = false;
     }
   }
 }

--- a/frontend/src/app/services/academico/oferta-import.service.ts
+++ b/frontend/src/app/services/academico/oferta-import.service.ts
@@ -61,6 +61,33 @@ export interface OfertaImportResultResponse {
   warnings: OfertaImportWarningResponse[];
 }
 
+export interface HorarioDto {
+  dia: string;
+  horaInicio: string;
+  horaFin: string;
+}
+
+export interface OfertaMateriaUpdateRequest {
+  codigoMateria: string;
+  nombreMateria: string;
+  paralelo: string;
+  semestre: string;
+  docente: string;
+  aula: string;
+  horarios: HorarioDto[];
+}
+
+export interface OfertaMateriaEdicionResponse {
+  id: number;
+  codigoMateria: string;
+  nombreMateria: string;
+  paralelo: string;
+  semestre: string;
+  docente: string;
+  aula: string;
+  horarios: HorarioDto[];
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -103,6 +130,26 @@ export class OfertaImportService {
   listarParalelos(mallaId: number): Observable<string[]> {
     return this.apiService.get<string[]>(
       `/api/academico/ofertas/paralelos?mallaId=${mallaId}`,
+    );
+  }
+
+  obtenerOfertaParaEdicion(id: number): Observable<OfertaMateriaEdicionResponse> {
+    return this.apiService.get<OfertaMateriaEdicionResponse>(
+      `/api/academico/ofertas/${id}/edicion`,
+    );
+  }
+
+  validarActualizacion(id: number, request: OfertaMateriaUpdateRequest): Observable<void> {
+    return this.apiService.post<void, OfertaMateriaUpdateRequest>(
+      `/api/academico/ofertas/${id}/validar`,
+      request,
+    );
+  }
+
+  actualizarOferta(id: number, request: OfertaMateriaUpdateRequest): Observable<void> {
+    return this.apiService.put<void, OfertaMateriaUpdateRequest>(
+      `/api/academico/ofertas/${id}`,
+      request,
     );
   }
 }

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.html
@@ -1,30 +1,31 @@
-<div class="confirm-overlay" (click)="onCancel()"></div>
+<div class="confirm-overlay" (click)="onCancel()">
+  <div
+    class="confirm-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="confirm-title"
+    aria-describedby="confirm-message"
+    (click)="$event.stopPropagation()"
+  >
+    <header class="confirm-modal__header">
+      <div>
+        <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
+        <h3 id="confirm-title">{{ title | translate }}</h3>
+      </div>
+      <button #focusTrapStart type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
+    </header>
 
-<div
-  class="confirm-modal"
-  role="dialog"
-  aria-modal="true"
-  aria-labelledby="confirm-title"
-  aria-describedby="confirm-message"
->
-  <header class="confirm-modal__header">
-    <div>
-      <p class="confirm-modal__eyebrow">{{ 'confirmModal.title' | translate }}</p>
-      <h3 id="confirm-title">{{ title | translate }}</h3>
+    <div class="confirm-modal__body">
+      <p id="confirm-message">{{ message | translate }}</p>
     </div>
-    <button #focusTrapStart type="button" class="confirm-modal__close" (click)="onCancel()">&times;</button>
-  </header>
 
-  <div class="confirm-modal__body">
-    <p id="confirm-message">{{ message | translate }}</p>
+    <footer class="confirm-modal__footer">
+      <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()" [disabled]="processing">
+        {{ cancelLabel | translate }}
+      </button>
+      <button #confirmBtn #focusTrapEnd type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()" [disabled]="processing">
+        {{ confirmLabel | translate }}
+      </button>
+    </footer>
   </div>
-
-  <footer class="confirm-modal__footer">
-    <button type="button" class="confirm-btn confirm-btn--ghost" (click)="onCancel()" [disabled]="processing">
-      {{ cancelLabel | translate }}
-    </button>
-    <button #confirmBtn #focusTrapEnd type="button" class="confirm-btn confirm-btn--danger" (click)="onConfirm()" [disabled]="processing">
-      {{ confirmLabel | translate }}
-    </button>
-  </footer>
 </div>

--- a/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
+++ b/frontend/src/app/shared/ui/confirm-modal/confirm-modal.scss
@@ -1,7 +1,7 @@
 .confirm-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: 9999;
   background: rgba(12, 18, 28, 0.54);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

This PR implements the academic offer editing flow, allowing users to load an existing offer, edit its information, validate possible classroom schedule conflicts, and save the changes.

It includes both backend support for retrieving/updating academic offers and frontend support for editing offers from the offer management table.

## Changes

- Added backend endpoint to retrieve an academic offer for editing:
  - `GET /api/academico/ofertas/{id}/edicion`
- Added backend endpoint to validate an offer update before saving:
  - `POST /api/academico/ofertas/{id}/validar`
- Added backend endpoint to update an academic offer:
  - `PUT /api/academico/ofertas/{id}`
- Added DTOs for:
  - offer edition response
  - offer update request
  - schedule blocks
- Added validation to detect classroom schedule conflicts by:
  - classroom
  - semester
  - day
  - start and end time overlap
- Updated schedule JSON handling to support `horaInicio` and `horaFin`.
- Added repository queries to find offers by classroom/semester and subjects by code within a malla.
- Added an edit action in the offer management table.
- Added an edit modal for academic offers with editable fields:
  - subject code
  - semester
  - parallel
  - teacher
  - classroom
  - schedule blocks
- Added frontend service methods for loading, validating, and updating offers.
- Added unit tests for backend offer editing logic.
- Added frontend tests for the offer edit flow.
- Fixed the shared confirmation modal structure and z-index so it works correctly above other modal overlays.

## Validation behavior

Before saving an edited offer, the system can validate whether the selected classroom already has another offer assigned in the same semester and overlapping time range. If a conflict is detected, the backend returns an error and the frontend displays the validation message.

## Tests
<img width="1503" height="490" alt="image" src="https://github.com/user-attachments/assets/d0b15c71-2c82-4c47-a2e6-d9570a1edac7" />
<img width="1918" height="903" alt="image" src="https://github.com/user-attachments/assets/4c4e7254-cf8a-4cf4-844b-20298d6f46d5" />
