### PR TITLE
HU-135-Mejora de usabilidad para el usuario y Corregir detalles para la Demo

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/academico/malla/service/MallaImportService.java
+++ b/backend/src/main/java/com/easyschedule/backend/academico/malla/service/MallaImportService.java
@@ -219,6 +219,7 @@ public class MallaImportService {
         List<Prerequisito> currentPrerequisitos = prerequisitoRepository
             .findByMallaMateria_Malla_IdOrPrerequisito_Malla_Id(mallaId, mallaId);
         prerequisitoRepository.deleteAll(currentPrerequisitos);
+        prerequisitoRepository.flush();
 
         Map<String, MallaMateria> updatedByCode = new LinkedHashMap<>();
         Set<Long> keptMallaMateriaIds = new HashSet<>();

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
@@ -11,6 +11,8 @@ import {
   OfertaMateriaUpdateRequest 
 } from '../../../services/academico/oferta-import.service';
 
+import { ToastService } from '../../../core/services/toast.service';
+
 @Component({
   selector: 'app-gestionar-ofertas',
   imports: [NgIf, NgFor, FormsModule, TranslatePipe],
@@ -37,7 +39,10 @@ export class GestionarOfertas implements OnInit {
   protected isValidating = false;
   protected isSaving = false;
 
-  constructor(private readonly ofertaImportService: OfertaImportService) {}
+  constructor(
+    private readonly ofertaImportService: OfertaImportService,
+    private readonly toastService: ToastService
+  ) {}
 
   async ngOnInit(): Promise<void> {
     if (this.mallaId === null) return;
@@ -204,6 +209,7 @@ export class GestionarOfertas implements OnInit {
         this.editingOferta.id, 
         this.buildUpdateRequest()
       ));
+      this.toastService.success('Oferta académica actualizada exitosamente');
       this.cerrarEdicion();
       await this.loadOfertas();
     } catch (e: any) {

--- a/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
+++ b/frontend/src/app/features/malla/gestionar-ofertas/gestionar-ofertas.ts
@@ -150,11 +150,29 @@ export class GestionarOfertas implements OnInit {
     };
   }
 
+  private hasValidTimeRanges(): boolean {
+    if (!this.editingOferta || !this.editingOferta.horarios) return true;
+    for (const horario of this.editingOferta.horarios) {
+      if (horario.horaInicio && horario.horaFin) {
+        if (horario.horaInicio >= horario.horaFin) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   protected async validarEdicion(): Promise<void> {
     if (!this.editingOferta) return;
     this.isValidating = true;
     this.editErrorMsg = '';
     this.editSuccessMsg = '';
+
+    if (!this.hasValidTimeRanges()) {
+      this.editErrorMsg = 'El horario de fin debe ser posterior al horario de inicio.';
+      this.isValidating = false;
+      return;
+    }
     
     try {
       await firstValueFrom(this.ofertaImportService.validarActualizacion(
@@ -174,6 +192,12 @@ export class GestionarOfertas implements OnInit {
     this.isSaving = true;
     this.editErrorMsg = '';
     this.editSuccessMsg = '';
+
+    if (!this.hasValidTimeRanges()) {
+      this.editErrorMsg = 'El horario de fin debe ser posterior al horario de inicio.';
+      this.isSaving = false;
+      return;
+    }
     
     try {
       await firstValueFrom(this.ofertaImportService.actualizarOferta(

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -4,9 +4,15 @@
       <p style="margin-bottom: 0.75rem; line-height: 1.5;">
         Estos son los estados de tus materias. Solo puedes cambiarlas manualmente a <strong>Pendiente</strong> o <strong>Completado</strong>. Para cambiar a <strong>En curso</strong> debes tomar la materia.
       </p>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
-        <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">No volver a mostrar</button>
-        <button class="malla-button malla-button--save" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="siguienteTour(2)">Siguiente</button>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 0.5rem;">
+        <span style="font-size: 0.75rem; color: #6f89ad; font-weight: 700; font-family: 'Poppins', sans-serif;">1/4</span>
+        <div style="display: flex; gap: 0.5rem;">
+          <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">Cerrar</button>
+          <div style="display: flex; gap: 0.25rem;">
+            <button class="malla-button malla-button--outline" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px; border-color: var(--color-blue); color: var(--color-blue);" disabled>&lt;</button>
+            <button class="malla-button malla-button--save" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px;" (click)="siguienteTour(2)">&gt;</button>
+          </div>
+        </div>
       </div>
     </div>
   </ng-template>
@@ -16,9 +22,15 @@
       <p style="margin-bottom: 0.75rem; line-height: 1.5;">
         Haz click sobre una materia para <strong>tomarla</strong> o <strong>cambiar su estado</strong>.
       </p>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
-        <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">No volver a mostrar</button>
-        <button class="malla-button malla-button--save" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="siguienteTour(3)">Siguiente</button>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 0.5rem;">
+        <span style="font-size: 0.75rem; color: #6f89ad; font-weight: 700; font-family: 'Poppins', sans-serif;">2/4</span>
+        <div style="display: flex; gap: 0.5rem;">
+          <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">Cerrar</button>
+          <div style="display: flex; gap: 0.25rem;">
+            <button class="malla-button malla-button--outline" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px; border-color: var(--color-blue); color: var(--color-blue);" (click)="siguienteTour(1)">&lt;</button>
+            <button class="malla-button malla-button--save" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px;" (click)="siguienteTour(3)">&gt;</button>
+          </div>
+        </div>
       </div>
     </div>
   </ng-template>
@@ -28,9 +40,15 @@
       <p style="margin-bottom: 0.75rem; line-height: 1.5;">
         Desde aquí puedes <strong>Cambiar Malla</strong> o <strong>Cambiar Universidad</strong> si lo necesitas.
       </p>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
-        <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">No volver a mostrar</button>
-        <button class="malla-button malla-button--save" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0;" (click)="finalizarTour()">¡Entendido!</button>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 0.5rem;">
+        <span style="font-size: 0.75rem; color: #6f89ad; font-weight: 700; font-family: 'Poppins', sans-serif;">4/4</span>
+        <div style="display: flex; gap: 0.5rem;">
+          <button class="malla-button malla-button--ghost" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0;" (click)="noVolverAMostrarTour()">Cerrar</button>
+          <div style="display: flex; gap: 0.25rem;">
+            <button class="malla-button malla-button--outline" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px; border-color: var(--color-blue); color: var(--color-blue);" (click)="siguienteTour(3)">&lt;</button>
+            <button class="malla-button malla-button--save" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; min-width: 32px;" (click)="finalizarTour()">✓</button>
+          </div>
+        </div>
       </div>
     </div>
   </ng-template>

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -39,7 +39,7 @@
   <section class="malla-page">
     <header class="malla-page__header">
       <h1>{{ 'malla.title' | translate }}</h1>
-      <p>{{ 'malla.description' | translate }}</p>
+      <p *ngIf="step === 'universidad'">{{ 'malla.description' | translate }}</p>
 
       <div class="malla-page__actions" *ngIf="step === 'resumen'"
            [ngbPopover]="tourStep4" triggers="manual" placement="bottom" popoverClass="hint-popover" #popoverStep4="ngbPopover">

--- a/frontend/src/app/features/malla/malla.scss
+++ b/frontend/src/app/features/malla/malla.scss
@@ -123,6 +123,10 @@
   color: #2b3442;
   margin-top: 0;
   line-height: 1.05;
+
+  &:hover:not(:disabled) {
+    color: #fff;
+  }
 }
 
 .malla-button--save {

--- a/frontend/src/app/features/malla/malla.scss
+++ b/frontend/src/app/features/malla/malla.scss
@@ -501,6 +501,14 @@
 
 .malla-modal--edit-malla {
   width: min(1180px, 98vw);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .malla-modal__body {
+    overflow-y: auto;
+    flex: 1;
+  }
 }
 
 .malla-modal__header {

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -102,6 +102,13 @@ export class Malla implements OnInit, OnDestroy {
 
   private flagsSubscription?: Subscription;
   private routerEventsSubscription?: Subscription;
+  protected importMallaSaving = false;
+  protected showImportConfirm = false;
+
+  protected currentTourStep = 0;
+
+  private routeSubscription: Subscription | undefined;
+  private featureToggleSubscription: Subscription | undefined;
   private tomaSeleccionSubscription?: Subscription;
   private previousSelectionSnapshot: SeleccionSnapshot | null = null;
   private materiasLoadedForMallaId: number | null = null;
@@ -1445,6 +1452,7 @@ Reglas obligatorias:
   }
 
   protected siguienteTour(step: number): void {
+    this.currentTourStep = step;
     this.popoverStep1?.close();
     this.popoverStep2?.close();
     this.popoverStep4?.close();
@@ -1470,9 +1478,29 @@ Reglas obligatorias:
   }
 
   protected finalizarTour(): void {
+    this.currentTourStep = 0;
     this.cerrarTodosLosPopovers();
     localStorage.setItem(this.getTourStorageKey(), 'true');
     this.persistirTourCompletado();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (this.currentTourStep > 0 && this.currentTourStep <= 4) {
+      const target = event.target as HTMLElement;
+      
+      // Si hizo click en un botón para avanzar o dentro del popover, ignoramos (el botón ya hace el avance)
+      if (target.closest('.popover') || target.closest('.hint-popover')) {
+        return;
+      }
+      
+      // Si hizo click fuera, avanzamos el tour automáticamente
+      if (this.currentTourStep < 4) {
+        this.siguienteTour(this.currentTourStep + 1);
+      } else {
+        this.finalizarTour();
+      }
+    }
   }
 
   protected toggleCrearUniversidad(): void {

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -110,6 +110,7 @@ export class Malla implements OnInit, OnDestroy {
   private routeSubscription: Subscription | undefined;
   private featureToggleSubscription: Subscription | undefined;
   private tomaSeleccionSubscription?: Subscription;
+  private tourHintsSubscription?: Subscription;
   private previousSelectionSnapshot: SeleccionSnapshot | null = null;
   private materiasLoadedForMallaId: number | null = null;
 

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -42,8 +42,8 @@ interface MallaEditRow {
   rowId: number;
   codigo: string;
   nombre: string;
-  semestre: number;
-  creditos: number;
+  semestre: number | null;
+  creditos: number | null;
   prerequisitos: string;
 }
 
@@ -337,15 +337,15 @@ Reglas obligatorias:
 
   protected addEditMallaRow(): void {
     this.editMallaRows = [
-      ...this.editMallaRows,
       {
         rowId: this.nextEditRowId++,
         codigo: '',
         nombre: '',
-        semestre: 1,
-        creditos: 4,
+        semestre: null,
+        creditos: null,
         prerequisitos: '',
       },
+      ...this.editMallaRows,
     ];
   }
 

--- a/frontend/src/app/layout/navbar/navbar.component.html
+++ b/frontend/src/app/layout/navbar/navbar.component.html
@@ -102,9 +102,15 @@
       <p style="margin-bottom: 0.75rem; line-height: 1.5;">
         ¡<strong>Armemos tu horario</strong>! Selecciona tus materias y construye tu horario del semestre.
       </p>
-      <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
-        <button type="button" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0; border: 1px solid rgba(34, 57, 90, 0.25); background-color: transparent; border-radius: 6px; color: #22395a; font-weight: 700; cursor: pointer; font-family: 'Poppins', sans-serif; transition: background-color 0.2s ease;" (click)="closeTourPopover()">No volver a mostrar</button>
-        <button type="button" style="padding: 0.25rem 0.6rem; font-size: 0.78rem; margin: 0; border: none; background-color: var(--color-blue); color: white; border-radius: 6px; font-weight: 700; cursor: pointer; font-family: 'Poppins', sans-serif; transition: background-color 0.2s ease;" (click)="closeTourPopover()">¡Entendido!</button>
+      <div style="display: flex; align-items: center; justify-content: space-between; margin-top: 0.5rem;">
+        <span style="font-size: 0.75rem; color: #6f89ad; font-weight: 700; font-family: 'Poppins', sans-serif;">3/4</span>
+        <div style="display: flex; gap: 0.5rem;">
+          <button type="button" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; border: none; background-color: transparent; border-radius: 6px; color: #22395a; font-weight: 700; cursor: pointer; font-family: 'Poppins', sans-serif;" (click)="closeTourPopover()">Cerrar</button>
+          <div style="display: flex; gap: 0.25rem;">
+            <button type="button" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; border: 1px solid var(--color-blue); background-color: transparent; color: var(--color-blue); border-radius: 6px; font-weight: 700; cursor: pointer; min-width: 32px;" (click)="requestTourStep(2)">&lt;</button>
+            <button type="button" style="padding: 0.25rem 0.5rem; font-size: 0.78rem; margin: 0; border: none; background-color: var(--color-blue); color: white; border-radius: 6px; font-weight: 700; cursor: pointer; min-width: 32px;" (click)="requestTourStep(4)">&gt;</button>
+          </div>
+        </div>
       </div>
     </div>
   </ng-template>

--- a/frontend/src/app/layout/navbar/navbar.component.html
+++ b/frontend/src/app/layout/navbar/navbar.component.html
@@ -6,7 +6,7 @@
     </span>
   </a>
 
-  <ul class="navbar__links">
+  <ul class="navbar__links" [class.navbar__links--open]="isMobileMenuOpen">
     <li>
       <a routerLink="/home" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">{{ 'navbar.home' | translate }}</a>
     </li>
@@ -83,6 +83,18 @@
         </div>
       </div>
     </details>
+
+    <button class="navbar__mobile-toggle" (click)="toggleMobileMenu()" [attr.aria-expanded]="isMobileMenuOpen">
+      <svg *ngIf="!isMobileMenuOpen" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="3" y1="12" x2="21" y2="12"></line>
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+      <svg *ngIf="isMobileMenuOpen" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"></line>
+        <line x1="6" y1="6" x2="18" y2="18"></line>
+      </svg>
+    </button>
   </div>
 
   <ng-template #tourStep3Template>

--- a/frontend/src/app/layout/navbar/navbar.component.scss
+++ b/frontend/src/app/layout/navbar/navbar.component.scss
@@ -272,7 +272,35 @@
   }
 }
 
+.navbar__mobile-toggle {
+  display: none;
+  background: transparent;
+  border: 1px solid rgba(34, 57, 90, 0.22);
+  border-radius: 999px;
+  color: #22395a;
+  width: 38px;
+  height: 38px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    background-color: rgba(111, 137, 172, 0.16);
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
 @media (max-width: 900px) {
+  .navbar__mobile-toggle {
+    display: inline-flex;
+  }
+
   .navbar {
     display: flex;
     width: 100%;
@@ -282,15 +310,37 @@
     gap: 0.75rem;
 
     &__links {
-      width: 100%;
-      justify-content: center;
-      flex-wrap: wrap;
-      order: 3;
-      gap: 0.45rem;
+      display: none;
+      position: absolute;
+      top: calc(100% + 0.45rem);
+      right: 1rem;
+      left: auto;
+      width: 220px;
+      background: #f7f3e7;
+      border: 1px solid rgba(34, 57, 90, 0.2);
+      border-radius: 14px;
+      padding: 0.65rem;
+      box-shadow: 0 10px 20px rgba(16, 16, 16, 0.12);
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.35rem;
+      z-index: 50;
+      order: unset;
+
+      &--open {
+        display: flex;
+      }
+
+      li {
+        width: 100%;
+      }
 
       a {
-        font-size: 0.95rem;
-        padding: 0.42rem 0.9rem;
+        display: block;
+        text-align: left;
+        font-size: 0.9rem;
+        padding: 0.5rem 0.8rem;
+        width: 100%;
       }
     }
 
@@ -331,22 +381,6 @@
     &__auth-btn {
       font-size: 0.8rem;
       padding: 0.36rem 0.68rem;
-    }
-
-    &__links {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-
-      li,
-      a {
-        width: 100%;
-      }
-
-      a {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
     }
   }
 

--- a/frontend/src/app/layout/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/navbar/navbar.component.ts
@@ -77,6 +77,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
       filter((event): event is NavigationEnd => event instanceof NavigationEnd)
     ).subscribe(() => {
       this.closeLanguageMenu();
+      this.closeMobileMenu();
     });
   }
 
@@ -94,6 +95,16 @@ export class NavbarComponent implements OnInit, OnDestroy {
     if (!clickedInside && this.languageMenuRef?.nativeElement?.open) {
       this.closeLanguageMenu();
     }
+  }
+
+  protected isMobileMenuOpen = false;
+
+  protected toggleMobileMenu(): void {
+    this.isMobileMenuOpen = !this.isMobileMenuOpen;
+  }
+
+  protected closeMobileMenu(): void {
+    this.isMobileMenuOpen = false;
   }
 
   protected setLanguage(lang: string): void {

--- a/frontend/src/app/layout/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/navbar/navbar.component.ts
@@ -146,4 +146,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   protected closeTourPopover(): void {
     this.tourHintsService.closeTomaMateriasPopover();
   }
+
+  protected requestTourStep(step: number): void {
+    this.tourHintsService.requestTourStep(step);
+  }
 }

--- a/frontend/src/app/services/tour-hints.service.ts
+++ b/frontend/src/app/services/tour-hints.service.ts
@@ -5,9 +5,11 @@ import { BehaviorSubject } from 'rxjs';
   providedIn: 'root',
 })
 export class TourHintsService {
-  // Observable para controlar si el popover de "Toma de Materias" debe estar abierto
   private tomaMateriasPopoverOpen$ = new BehaviorSubject<boolean>(false);
   tomaMateriasPopoverOpen = this.tomaMateriasPopoverOpen$.asObservable();
+
+  private tourStepRequest$ = new BehaviorSubject<number | null>(null);
+  tourStepRequest = this.tourStepRequest$.asObservable();
 
   openTomaMateriasPopover(): void {
     this.tomaMateriasPopoverOpen$.next(true);
@@ -15,5 +17,9 @@ export class TourHintsService {
 
   closeTomaMateriasPopover(): void {
     this.tomaMateriasPopoverOpen$.next(false);
+  }
+
+  requestTourStep(step: number): void {
+    this.tourStepRequest$.next(step);
   }
 }

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  backendUrl: '',
+  backendUrl: 'https://easyschedule-hjzc.onrender.com',
   googleClientId: '692611066828-hnsrfqs4kpi6dbf8427qi33tcvmde4dk.apps.googleusercontent.com'
 };


### PR DESCRIPTION
## Description

This PR improves the overall usability of the malla and offer management flows, focusing on demo readiness, mobile navigation, validation feedback, and small stability fixes.

## Changes

- Added a production backend URL in the frontend environment configuration so API calls no longer point to the Netlify frontend domain.
- Added a mobile hamburger menu for the navbar.
- The mobile navbar now opens/closes correctly and automatically closes when navigating to another route.
- Improved the guided tour UI by adding:
  - step counters such as `1/4`, `2/4`, `3/4`, `4/4`
  - previous/next navigation buttons
  - a clearer close action
  - support for requesting tour steps from the navbar.
- Added click-outside behavior to advance or finish the malla guided tour.
- Improved the malla page header so the introductory description only appears during the university selection step.
- Improved the edit malla modal layout by making its body scrollable and preventing overflow issues.
- Changed new editable malla rows so they are inserted at the top and start with empty semester/credits values instead of default values.
- Added frontend validation for offer edition time ranges:
  - prevents saving or validating when `horaFin` is not after `horaInicio`.
- Added a success toast when an academic offer is updated correctly.
- Added a backend flush after deleting prerequisites during malla update to avoid persistence/order issues when replacing prerequisite relations.

## Why

These changes polish the user experience before the demo, especially in mobile views and guided flows. They also prevent common user mistakes such as invalid offer schedules and fix the frontend production API configuration.

## Hamburger on mobile view
<img width="524" height="890" alt="image" src="https://github.com/user-attachments/assets/443fe27d-5632-4b13-8618-3c2f5c433c69" />

## Pop up improve
### counter
<img width="1864" height="1002" alt="image" src="https://github.com/user-attachments/assets/3c5b83ef-3bc7-49b5-959f-86fe03e734d7" />

### dont show again
<img width="1871" height="993" alt="image" src="https://github.com/user-attachments/assets/c3a7c308-9cc5-4736-99ff-333fec774761" />

## tests
<img width="1914" height="1075" alt="image" src="https://github.com/user-attachments/assets/7158fc17-d89b-498e-b1d1-28a32e776d5f" />

<img width="1898" height="1076" alt="image" src="https://github.com/user-attachments/assets/44ac34da-0be7-43d0-9d97-15d89ded63f8" />
