### PR TITLE
HU-157- Eliminacion de Feature Toggle

### DIFF
--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsConfig.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsConfig.java
@@ -7,25 +7,18 @@ import org.springframework.stereotype.Component;
 public class FeatureFlagsConfig {
 
     private final boolean malla;
-    private final boolean tomaMaterias;
     private final boolean ofertasImport;
 
     public FeatureFlagsConfig(
         @Value("${features.malla:true}") boolean malla,
-        @Value("${features.toma-materias:true}") boolean tomaMaterias,
         @Value("${features.ofertas-import:true}") boolean ofertasImport
     ) {
         this.malla = malla;
-        this.tomaMaterias = tomaMaterias;
         this.ofertasImport = ofertasImport;
     }
 
     public boolean isMalla() {
         return malla;
-    }
-
-    public boolean isTomaMaterias() {
-        return tomaMaterias;
     }
 
     public boolean isOfertasImport() {

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsConfig.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsConfig.java
@@ -1,27 +1,11 @@
 package com.easyschedule.backend.shared.feature;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FeatureFlagsConfig {
 
-    private final boolean malla;
-    private final boolean ofertasImport;
-
-    public FeatureFlagsConfig(
-        @Value("${features.malla:true}") boolean malla,
-        @Value("${features.ofertas-import:true}") boolean ofertasImport
-    ) {
-        this.malla = malla;
-        this.ofertasImport = ofertasImport;
+    public FeatureFlagsConfig() {
     }
 
-    public boolean isMalla() {
-        return malla;
-    }
-
-    public boolean isOfertasImport() {
-        return ofertasImport;
-    }
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDTO.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDTO.java
@@ -2,7 +2,6 @@ package com.easyschedule.backend.shared.feature;
 
 public record FeatureFlagsDTO(
     boolean malla,
-    boolean tomaMaterias,
     boolean ofertasImport
 ) {
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDTO.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureFlagsDTO.java
@@ -1,7 +1,4 @@
 package com.easyschedule.backend.shared.feature;
 
-public record FeatureFlagsDTO(
-    boolean malla,
-    boolean ofertasImport
-) {
+public record FeatureFlagsDTO() {
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
@@ -14,7 +14,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class FeatureToggleInterceptor implements HandlerInterceptor {
 
     private static final String MALLA = "malla";
-    private static final String TOMA_MATERIAS = "tomaMaterias";
     private static final String OFERTAS_IMPORT = "ofertasImport";
 
     private static final List<String> MALLA_PATH_PREFIXES = List.of(
@@ -29,11 +28,6 @@ public class FeatureToggleInterceptor implements HandlerInterceptor {
 
     private static final List<String> OFERTAS_IMPORT_PATH_PREFIXES = List.of(
         "/api/academico/ofertas/importar"
-    );
-
-    private static final List<String> TOMA_MATERIAS_PATH_PREFIXES = List.of(
-        "/api/academico/toma-materias",
-        "/api/academico/horario"
     );
 
     private final FeatureToggleService featureToggleService;
@@ -52,10 +46,6 @@ public class FeatureToggleInterceptor implements HandlerInterceptor {
 
         if (!featureToggleService.isEnabled(OFERTAS_IMPORT) && matchesAny(requestPath, OFERTAS_IMPORT_PATH_PREFIXES)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La importacion de ofertas esta deshabilitada");
-        }
-
-        if (!featureToggleService.isEnabled(TOMA_MATERIAS) && matchesAny(requestPath, TOMA_MATERIAS_PATH_PREFIXES)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La funcionalidad de toma de materias esta deshabilitada");
         }
 
         return true;

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleInterceptor.java
@@ -13,23 +13,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @ConditionalOnBean(FeatureToggleService.class)
 public class FeatureToggleInterceptor implements HandlerInterceptor {
 
-    private static final String MALLA = "malla";
-    private static final String OFERTAS_IMPORT = "ofertasImport";
-
-    private static final List<String> MALLA_PATH_PREFIXES = List.of(
-        "/api/academico/universidades",
-        "/api/academico/carreras",
-        "/api/academico/mallas",
-        "/api/academico/seleccion",
-        "/api/academico/estados-materia",
-        "/api/estudiantes/me/avance-graduacion",
-        "/api/academico/prerequisitos"
-    );
-
-    private static final List<String> OFERTAS_IMPORT_PATH_PREFIXES = List.of(
-        "/api/academico/ofertas/importar"
-    );
-
     private final FeatureToggleService featureToggleService;
 
     public FeatureToggleInterceptor(FeatureToggleService featureToggleService) {
@@ -38,26 +21,6 @@ public class FeatureToggleInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        String requestPath = request.getRequestURI();
-
-        if (!featureToggleService.isEnabled(MALLA) && matchesAny(requestPath, MALLA_PATH_PREFIXES)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La funcionalidad de malla esta deshabilitada");
-        }
-
-        if (!featureToggleService.isEnabled(OFERTAS_IMPORT) && matchesAny(requestPath, OFERTAS_IMPORT_PATH_PREFIXES)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "La importacion de ofertas esta deshabilitada");
-        }
-
         return true;
-    }
-
-    private boolean matchesAny(String requestPath, List<String> prefixes) {
-        for (String prefix : prefixes) {
-            if (requestPath.equals(prefix) || requestPath.startsWith(prefix + "/")) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleService.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleService.java
@@ -10,8 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class FeatureToggleService {
 
-    private static final String MALLA = "malla";
-    private static final String OFERTAS_IMPORT = "ofertasImport";
+
 
     private final FeatureToggleRepository featureToggleRepository;
     private final FeatureFlagsConfig featureFlagsConfig;
@@ -24,10 +23,7 @@ public class FeatureToggleService {
     @Transactional
     public FeatureFlagsDTO getFeatureFlags() {
         ensureDefaultToggles();
-        return new FeatureFlagsDTO(
-            isEnabled(MALLA),
-            isEnabled(OFERTAS_IMPORT)
-        );
+        return new FeatureFlagsDTO();
     }
 
     @Transactional
@@ -104,20 +100,7 @@ public class FeatureToggleService {
     }
 
     private List<FeatureToggleDefinition> defaultToggles() {
-        return List.of(
-            new FeatureToggleDefinition(
-                MALLA,
-                "Malla curricular",
-                "Controla el acceso a la gestion y visualizacion de mallas curriculares.",
-                featureFlagsConfig.isMalla()
-            ),
-            new FeatureToggleDefinition(
-                OFERTAS_IMPORT,
-                "Importacion de ofertas",
-                "Controla la importacion de ofertas academicas.",
-                featureFlagsConfig.isOfertasImport()
-            )
-        );
+        return List.of();
     }
 
     private record FeatureToggleDefinition(String key, String name, String description, boolean active) {}

--- a/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleService.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/feature/FeatureToggleService.java
@@ -11,7 +11,6 @@ import org.springframework.web.server.ResponseStatusException;
 public class FeatureToggleService {
 
     private static final String MALLA = "malla";
-    private static final String TOMA_MATERIAS = "tomaMaterias";
     private static final String OFERTAS_IMPORT = "ofertasImport";
 
     private final FeatureToggleRepository featureToggleRepository;
@@ -27,7 +26,6 @@ public class FeatureToggleService {
         ensureDefaultToggles();
         return new FeatureFlagsDTO(
             isEnabled(MALLA),
-            isEnabled(TOMA_MATERIAS),
             isEnabled(OFERTAS_IMPORT)
         );
     }
@@ -112,12 +110,6 @@ public class FeatureToggleService {
                 "Malla curricular",
                 "Controla el acceso a la gestion y visualizacion de mallas curriculares.",
                 featureFlagsConfig.isMalla()
-            ),
-            new FeatureToggleDefinition(
-                TOMA_MATERIAS,
-                "Toma de materias",
-                "Controla el acceso al modulo de toma de materias y horarios.",
-                featureFlagsConfig.isTomaMaterias()
             ),
             new FeatureToggleDefinition(
                 OFERTAS_IMPORT,

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsControllerTest.java
@@ -40,12 +40,10 @@ class FeatureFlagsControllerTest {
 
     @Test
     void getFeatureFlagsReturnsCurrentFlags() throws Exception {
-        when(featureToggleService.getFeatureFlags()).thenReturn(new FeatureFlagsDTO(true, true));
+        when(featureToggleService.getFeatureFlags()).thenReturn(new FeatureFlagsDTO());
 
         mockMvc.perform(get("/api/features"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.malla").value(true))
-            .andExpect(jsonPath("$.ofertasImport").value(true));
+            .andExpect(status().isOk());
     }
 
     @Test

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsControllerTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureFlagsControllerTest.java
@@ -40,12 +40,11 @@ class FeatureFlagsControllerTest {
 
     @Test
     void getFeatureFlagsReturnsCurrentFlags() throws Exception {
-        when(featureToggleService.getFeatureFlags()).thenReturn(new FeatureFlagsDTO(true, false, true));
+        when(featureToggleService.getFeatureFlags()).thenReturn(new FeatureFlagsDTO(true, true));
 
         mockMvc.perform(get("/api/features"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.malla").value(true))
-            .andExpect(jsonPath("$.tomaMaterias").value(false))
             .andExpect(jsonPath("$.ofertasImport").value(true));
     }
 

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleServiceTest.java
@@ -25,7 +25,7 @@ class FeatureToggleServiceTest {
     void updateStatusRefreshesUpdatedAt() {
         FeatureToggleService service = new FeatureToggleService(
             featureToggleRepository,
-            new FeatureFlagsConfig(true, true)
+            new FeatureFlagsConfig()
         );
         OffsetDateTime previousUpdatedAt = OffsetDateTime.now().minusDays(1);
         FeatureToggle toggle = new FeatureToggle(
@@ -36,7 +36,7 @@ class FeatureToggleServiceTest {
         );
         toggle.setUpdatedAt(previousUpdatedAt);
 
-        when(featureToggleRepository.existsByKey(anyString())).thenReturn(true);
+
         when(featureToggleRepository.findByKey("malla")).thenReturn(Optional.of(toggle));
         when(featureToggleRepository.save(any(FeatureToggle.class))).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleServiceTest.java
+++ b/backend/src/test/java/com/easyschedule/backend/shared/feature/FeatureToggleServiceTest.java
@@ -25,7 +25,7 @@ class FeatureToggleServiceTest {
     void updateStatusRefreshesUpdatedAt() {
         FeatureToggleService service = new FeatureToggleService(
             featureToggleRepository,
-            new FeatureFlagsConfig(true, true, true)
+            new FeatureFlagsConfig(true, true)
         );
         OffsetDateTime previousUpdatedAt = OffsetDateTime.now().minusDays(1);
         FeatureToggle toggle = new FeatureToggle(

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -21,7 +21,7 @@ export const routes: Routes = [
   },
   {
     path: 'toma-de-materias',
-    canActivate: [authGuard, featureGuard('tomaMaterias'), profileCompletedGuard],
+    canActivate: [authGuard, profileCompletedGuard],
     loadChildren: () =>
       import('./features/toma-de-materias/toma-de-materias.routes').then(
         (m) => m.TOMA_DE_MATERIAS_ROUTES,

--- a/frontend/src/app/features/admin-feature-toggles/admin-feature-toggles.ts
+++ b/frontend/src/app/features/admin-feature-toggles/admin-feature-toggles.ts
@@ -57,7 +57,7 @@ export class AdminFeatureToggles implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (toggles) => {
-          this.toggles = toggles;
+          this.toggles = toggles.filter(t => !['malla', 'tomaMaterias', 'ofertasImport'].includes(t.key as string));
           this.loading = false;
         },
         error: (error: HttpErrorResponse) => {
@@ -88,7 +88,7 @@ export class AdminFeatureToggles implements OnInit {
     }
 
     const { toggle, active } = this.pendingUpdate;
-    this.savingKey = toggle.key;
+    this.savingKey = toggle.key as string;
     this.featureToggleService
       .updateToggle(toggle.key, active)
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/frontend/src/app/features/home/home.ts
+++ b/frontend/src/app/features/home/home.ts
@@ -34,8 +34,6 @@ export class Home {
       return;
     }
 
-    if (this.featureToggleService.isEnabled('tomaMaterias')) {
-      void this.router.navigate(['/toma-de-materias']);
-    }
+    void this.router.navigate(['/toma-de-materias']);
   }
 }

--- a/frontend/src/app/features/home/home.ts
+++ b/frontend/src/app/features/home/home.ts
@@ -3,7 +3,6 @@ import { Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 
 import { AuthSessionService } from '../../core/services/auth-session.service';
-import { FeatureToggleService } from '../../services/feature-toggle.service';
 
 @Component({
   selector: 'app-home',
@@ -15,7 +14,6 @@ export class Home {
   constructor(
     private readonly authSessionService: AuthSessionService,
     private readonly router: Router,
-    private readonly featureToggleService: FeatureToggleService,
   ) {}
 
   protected goToStart(): void {
@@ -29,11 +27,6 @@ export class Home {
       return;
     }
 
-    if (this.featureToggleService.isEnabled('malla')) {
-      void this.router.navigate(['/malla']);
-      return;
-    }
-
-    void this.router.navigate(['/toma-de-materias']);
+    void this.router.navigate(['/malla']);
   }
 }

--- a/frontend/src/app/features/malla/actualizar-malla/actualizar-malla.scss
+++ b/frontend/src/app/features/malla/actualizar-malla/actualizar-malla.scss
@@ -70,6 +70,10 @@
   border: 1px solid rgba(47, 79, 115, 0.25);
   background: transparent;
   color: var(--color-blue-dark);
+
+  &:hover:not(:disabled) {
+    color: #fff;
+  }
 }
 
 .malla-warning {

--- a/frontend/src/app/features/malla/malla.html
+++ b/frontend/src/app/features/malla/malla.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="mallaEnabled">
+<ng-container>
   <ng-template #tourStep1>
     <div style="max-width: 280px;">
       <p style="margin-bottom: 0.75rem; line-height: 1.5;">
@@ -62,7 +62,7 @@
       <div class="malla-page__actions" *ngIf="step === 'resumen'"
            [ngbPopover]="tourStep4" triggers="manual" placement="bottom" popoverClass="hint-popover" #popoverStep4="ngbPopover">
 
-        <button type="button" class="malla-button malla-button--outline" *ngIf="ofertasImportEnabled" [disabled]="materias.length === 0" (click)="onImportarOfertasClick()">
+        <button type="button" class="malla-button malla-button--outline" [disabled]="materias.length === 0" (click)="onImportarOfertasClick()">
         {{ 'malla.actions.importOffers' | translate }}
         </button>
         <button type="button" class="malla-button malla-button--outline" [disabled]="materias.length === 0" (click)="onGestionarOfertasClick()">

--- a/frontend/src/app/features/malla/malla.scss
+++ b/frontend/src/app/features/malla/malla.scss
@@ -138,6 +138,10 @@
   border: 1px solid rgba(47, 79, 115, 0.25);
   background: transparent;
   color: var(--color-blue-dark);
+
+  &:hover:not(:disabled) {
+    color: #fff;
+  }
 }
 
 .malla-section {

--- a/frontend/src/app/features/malla/malla.spec.ts
+++ b/frontend/src/app/features/malla/malla.spec.ts
@@ -12,7 +12,6 @@ import { CarreraService } from '../../services/academico/carrera.service';
 import { MallaCatalogoService } from '../../services/academico/malla-catalogo.service';
 import { SeleccionAcademicaService } from '../../services/academico/seleccion-academica.service';
 import { UniversidadService } from '../../services/academico/universidad.service';
-import { FeatureToggleService, FeatureFlags } from '../../services/feature-toggle.service';
 import { TomaSeleccionService } from '../../services/academico/toma-seleccion.service';
 import { TranslateService } from '@ngx-translate/core';
 import { AuthSessionService } from '../../core/services/auth-session.service';
@@ -24,8 +23,6 @@ import { EstadoMateriaService } from '../../services/academico/estado-materia.se
 
 describe('Malla component logic', () => {
   let component: Malla;
-  let flagsSubject: BehaviorSubject<FeatureFlags>;
-  let featureServiceMock: jasmine.SpyObj<FeatureToggleService> & { flags$: BehaviorSubject<FeatureFlags> };
   let universidadServiceSpy: jasmine.SpyObj<UniversidadService>;
   let carreraServiceSpy: jasmine.SpyObj<CarreraService>;
   let mallaCatalogoServiceSpy: jasmine.SpyObj<MallaCatalogoService>;
@@ -43,12 +40,6 @@ describe('Malla component logic', () => {
   let activatedRouteStub: any;
 
   beforeEach(() => {
-    flagsSubject = new BehaviorSubject<FeatureFlags>({ malla: true, tomaMaterias: false, ofertasImport: true });
-
-    featureServiceMock = jasmine.createSpyObj<FeatureToggleService>('FeatureToggleService', ['loadFlags']) as any;
-    featureServiceMock.flags$ = flagsSubject;
-    featureServiceMock.loadFlags.and.returnValue(Promise.resolve());
-
     universidadServiceSpy = jasmine.createSpyObj<UniversidadService>('UniversidadService', ['getUniversidadesActivas']);
     carreraServiceSpy = jasmine.createSpyObj<CarreraService>('CarreraService', ['getCarrerasActivasPorUniversidad']);
     mallaCatalogoServiceSpy = jasmine.createSpyObj<MallaCatalogoService>('MallaCatalogoService', [
@@ -86,7 +77,6 @@ describe('Malla component logic', () => {
     activatedRouteStub = { snapshot: { queryParams: {} } };
 
     component = new (Malla as any)(
-      featureServiceMock,
       universidadServiceSpy,
       carreraServiceSpy,
       mallaCatalogoServiceSpy,
@@ -369,7 +359,6 @@ describe('Malla component logic', () => {
     await TestBed.configureTestingModule({
       imports: [Malla, TranslateModule.forRoot()],
       providers: [
-        { provide: FeatureToggleService, useValue: featureServiceMock },
         { provide: UniversidadService, useValue: universidadServiceSpy },
         { provide: CarreraService, useValue: carreraServiceSpy },
         { provide: MallaCatalogoService, useValue: mallaCatalogoServiceSpy },

--- a/frontend/src/app/features/malla/malla.ts
+++ b/frontend/src/app/features/malla/malla.ts
@@ -10,7 +10,6 @@ import { NgbPopover, NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
 import { environment } from '../../../environments/environment';
 import { CarreraCatalogoItem, CarreraService } from '../../services/academico/carrera.service';
 import { EstadoMateriaService, EstadoMateriaRequest } from '../../services/academico/estado-materia.service';
-import { FeatureToggleService } from '../../services/feature-toggle.service';
 import { MallaCatalogoItem, MallaCatalogoService, MallaEditableMateria, MallaMateria } from '../../services/academico/malla-catalogo.service';
 import {
   SeleccionAcademica,
@@ -64,7 +63,6 @@ interface MallaEditRow {
   styleUrl: './malla.scss',
 })
 export class Malla implements OnInit, OnDestroy {
-  protected mallaEnabled = false;
   protected step: SeleccionStep = 'universidad';
   protected editMode: EditMode = null;
 
@@ -108,7 +106,6 @@ export class Malla implements OnInit, OnDestroy {
   protected currentTourStep = 0;
 
   private routeSubscription: Subscription | undefined;
-  private featureToggleSubscription: Subscription | undefined;
   private tomaSeleccionSubscription?: Subscription;
   private tourHintsSubscription?: Subscription;
   private previousSelectionSnapshot: SeleccionSnapshot | null = null;
@@ -122,7 +119,6 @@ export class Malla implements OnInit, OnDestroy {
   protected selectedOfertaId: number | null = null;
   protected materiasSeleccionadas: Set<number> = new Set();
 
-  protected ofertasImportEnabled = true;
   protected showImportarOfertasModal = false;
   protected showGestionarOfertasModal = false;
 
@@ -220,7 +216,6 @@ Reglas obligatorias:
   protected loadingSelecciones = false;
 
   constructor(
-    private readonly featureService: FeatureToggleService,
     private readonly universidadService: UniversidadService,
     private readonly carreraService: CarreraService,
     private readonly mallaCatalogoService: MallaCatalogoService,
@@ -239,10 +234,6 @@ Reglas obligatorias:
   ) {}
 
   ngOnInit(): void {
-    this.flagsSubscription = this.featureService.flags$.subscribe((flags) => {
-      this.mallaEnabled = flags.malla;
-      this.ofertasImportEnabled = flags.ofertasImport ?? true;
-    });
 
     this.routerEventsSubscription = this.router.events
       .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
@@ -259,13 +250,11 @@ Reglas obligatorias:
       this.materiasSeleccionadas = new Set(materias.map((materia) => materia.id));
     });
 
-    void this.featureService.loadFlags();
     void this.loadUniversidades();
     void this.cargarSeleccionesTemporales();
   }
 
   ngOnDestroy(): void {
-    this.flagsSubscription?.unsubscribe();
     this.routerEventsSubscription?.unsubscribe();
     this.tomaSeleccionSubscription?.unsubscribe();
   }

--- a/frontend/src/app/layout/navbar/navbar.component.html
+++ b/frontend/src/app/layout/navbar/navbar.component.html
@@ -10,7 +10,7 @@
     <li>
       <a routerLink="/home" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">{{ 'navbar.home' | translate }}</a>
     </li>
-    <li *ngIf="isLoggedIn() && !isAdmin() && mallaEnabled">
+    <li *ngIf="isLoggedIn() && !isAdmin()">
       <a routerLink="/malla" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }"
          [ngbPopover]="('navbar.hints.chooseMalla' | translate)"
          triggers="manual"

--- a/frontend/src/app/layout/navbar/navbar.component.html
+++ b/frontend/src/app/layout/navbar/navbar.component.html
@@ -19,7 +19,7 @@
          #mallaPopover="ngbPopover"
       >{{ 'navbar.malla' | translate }}</a>
     </li>
-    <li *ngIf="isLoggedIn() && !isAdmin() && tomaMateriasEnabled">
+    <li *ngIf="isLoggedIn() && !isAdmin()">
       <a routerLink="/toma-de-materias" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }"
          [ngbPopover]="tourStep3Template"
          triggers="manual"

--- a/frontend/src/app/layout/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/navbar/navbar.component.ts
@@ -19,7 +19,6 @@ import { TourHintsService } from '../../services/tour-hints.service';
 })
 export class NavbarComponent implements OnInit, OnDestroy {
   protected mallaEnabled = false;
-  protected tomaMateriasEnabled = false;
   protected currentLanguage: string = 'es';
   private flagsSubscription?: Subscription;
   private profileCompletedSubscription?: Subscription;
@@ -44,7 +43,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.flagsSubscription = this.featureToggleService.flags$.subscribe((flags) => {
       this.mallaEnabled = flags.malla;
-      this.tomaMateriasEnabled = flags.tomaMaterias;
     });
 
     void this.featureToggleService.loadFlags();

--- a/frontend/src/app/layout/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/navbar/navbar.component.ts
@@ -7,7 +7,6 @@ import { Subscription, filter } from 'rxjs';
 import { LanguageService } from '../../core/services/language.service';
 import { NgbPopover, NgbPopoverModule } from '@ng-bootstrap/ng-bootstrap';
 import { AuthSessionService } from '../../core/services/auth-session.service';
-import { FeatureToggleService } from '../../services/feature-toggle.service';
 import { ApiService } from '../../services/api.service';
 import { TourHintsService } from '../../services/tour-hints.service';
 
@@ -18,9 +17,7 @@ import { TourHintsService } from '../../services/tour-hints.service';
   styleUrl: './navbar.component.scss',
 })
 export class NavbarComponent implements OnInit, OnDestroy {
-  protected mallaEnabled = false;
   protected currentLanguage: string = 'es';
-  private flagsSubscription?: Subscription;
   private profileCompletedSubscription?: Subscription;
   private tomaMateriasPopoverSubscription?: Subscription;
   private languageSubscription?: Subscription;
@@ -35,17 +32,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
     private readonly router: Router,
     private readonly languageService: LanguageService,
     private readonly authSessionService: AuthSessionService,
-    private readonly featureToggleService: FeatureToggleService,
     private readonly apiService: ApiService,
     private readonly tourHintsService: TourHintsService,
   ) {}
 
   ngOnInit(): void {
-    this.flagsSubscription = this.featureToggleService.flags$.subscribe((flags) => {
-      this.mallaEnabled = flags.malla;
-    });
-
-    void this.featureToggleService.loadFlags();
 
     this.profileCompletedSubscription = this.authSessionService.profileCompleted$.subscribe((completed) => {
       if (completed && this.mallaPopover) {
@@ -80,7 +71,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.flagsSubscription?.unsubscribe();
     this.profileCompletedSubscription?.unsubscribe();
     this.tomaMateriasPopoverSubscription?.unsubscribe();
     this.languageSubscription?.unsubscribe();

--- a/frontend/src/app/services/feature-toggle.service.ts
+++ b/frontend/src/app/services/feature-toggle.service.ts
@@ -6,7 +6,6 @@ import { environment } from '../../environments/environment';
 
 export interface FeatureFlags {
   malla: boolean;
-  tomaMaterias: boolean;
   ofertasImport: boolean;
 }
 
@@ -26,7 +25,6 @@ export interface FeatureToggle {
 export class FeatureToggleService {
   private flags: FeatureFlags = {
     malla: false,
-    tomaMaterias: false,
     ofertasImport: true,
   };
   private readonly flagsSubject = new BehaviorSubject<FeatureFlags>(this.flags);

--- a/frontend/src/app/services/feature-toggle.service.ts
+++ b/frontend/src/app/services/feature-toggle.service.ts
@@ -5,8 +5,7 @@ import { BehaviorSubject, Observable, firstValueFrom, tap } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface FeatureFlags {
-  malla: boolean;
-  ofertasImport: boolean;
+  [key: string]: boolean;
 }
 
 export type FeatureName = keyof FeatureFlags;
@@ -23,10 +22,7 @@ export interface FeatureToggle {
   providedIn: 'root',
 })
 export class FeatureToggleService {
-  private flags: FeatureFlags = {
-    malla: false,
-    ofertasImport: true,
-  };
+  private flags: FeatureFlags = {};
   private readonly flagsSubject = new BehaviorSubject<FeatureFlags>(this.flags);
   readonly flags$ = this.flagsSubject.asObservable();
 


### PR DESCRIPTION
## Description

This PR removes the current feature toggles for `malla`, `tomaMaterias` and `ofertasImport` from the application behavior, while preserving the general feature toggle infrastructure for future use.

## Changes

- Removed the specific backend configuration values for:
  - `malla`
  - `tomaMaterias`
  - `ofertasImport`
- Updated `FeatureFlagsDTO` so it no longer exposes those three flags.
- Removed backend access blocking logic from `FeatureToggleInterceptor` for:
  - malla routes
  - toma de materias routes
  - offer import routes
- Updated `FeatureToggleService` so it no longer creates those three default toggles.
- Kept the feature toggle service, controller, repository, interceptor structure and admin infrastructure available for future toggles.
- Removed the `featureGuard('tomaMaterias')` from the toma de materias route.
- Updated the home navigation so users are sent directly to `/malla`.
- Removed feature toggle checks from the malla page.
- Made the import offers action always available when there are materias.
- Updated the admin feature toggles panel to hide the removed toggles if they still exist in persisted data.
- Adjusted tests to match the removal of those specific flags.
- Added small hover style improvements for outline buttons.
## before vs after
<img width="1217" height="689" alt="image" src="https://github.com/user-attachments/assets/0c29d5bf-929e-4a02-8c85-a563a7f7ad09" />

## tests
<img width="1914" height="1075" alt="image" src="https://github.com/user-attachments/assets/7158fc17-d89b-498e-b1d1-28a32e776d5f" />

<img width="1898" height="1076" alt="image" src="https://github.com/user-attachments/assets/44ac34da-0be7-43d0-9d97-15d89ded63f8" />