### PR TITLE
HU-159 swagger

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 	implementation("com.github.librepdf:openpdf:1.3.30")
 	implementation("com.google.api-client:google-api-client:2.7.2")
 	implementation("com.google.http-client:google-http-client-gson:1.45.0")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/easyschedule/backend/auth/controllers/AuthController.java
+++ b/backend/src/main/java/com/easyschedule/backend/auth/controllers/AuthController.java
@@ -21,8 +21,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.server.ResponseStatusException;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Autenticación", description = "Endpoints para registro y login de usuarios")
 public class AuthController {
 
     private static final Logger log = LoggerFactory.getLogger(AuthController.class);
@@ -33,6 +39,8 @@ public class AuthController {
         this.authService = authService;
     }
 
+    @Operation(summary = "Registrar un nuevo usuario", description = "Crea una nueva cuenta de usuario en el sistema.")
+    @SecurityRequirements()
     @PostMapping("/registro")
     public ResponseEntity<Void> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
         String identifier = signUpRequest.getUsername() == null ? "" : signUpRequest.getUsername().trim();
@@ -48,6 +56,8 @@ public class AuthController {
         }
     }
 
+    @Operation(summary = "Iniciar sesión", description = "Autentica al usuario usando sus credenciales y devuelve un token JWT.")
+    @SecurityRequirements()
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         String identifier = request.getIdentifier() == null ? "" : request.getIdentifier().trim();

--- a/backend/src/main/java/com/easyschedule/backend/shared/config/SecurityConfig.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/estudiantes/registro").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/features").permitAll()
                 .requestMatchers(HttpMethod.GET, "/health").permitAll()
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(bearerTokenAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/easyschedule/backend/shared/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/easyschedule/backend/shared/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.easyschedule.backend.shared.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+        return new OpenAPI()
+                .info(new Info()
+                        .title("EasySchedule API")
+                        .version("1.0")
+                        .description("Documentación de la API de EasySchedule"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}


### PR DESCRIPTION
## Description

This PR adds Swagger/OpenAPI documentation support to the EasySchedule backend.

It integrates `springdoc-openapi` so the API can be explored from Swagger UI and documents the authentication endpoints for registration and login.

## Changes

- Added the `springdoc-openapi-starter-webmvc-ui` dependency.
- Added Swagger/OpenAPI configuration with:
  - API title: `EasySchedule API`
  - version: `1.0`
  - general API description
  - JWT Bearer authentication scheme
- Enabled public access to Swagger-related endpoints:
  - `/v3/api-docs/**`
  - `/swagger-ui/**`
  - `/swagger-ui.html`
  - `/swagger-resources/**`
- Added Swagger annotations to `AuthController`:
  - `@Tag` for authentication endpoints
  - `@Operation` for user registration
  - `@Operation` for login
- Marked registration and login endpoints as public in the generated documentation using `@SecurityRequirements`.

## Expected behavior

- Swagger UI should be accessible without authentication.
- API documentation should show the authentication endpoints with clear descriptions.
- Secured endpoints can be documented using the configured Bearer JWT scheme.
- Existing backend security behavior should remain unchanged for protected API routes.

## ScreenShot
URL: http://localhost:8080/swagger-ui.html
<img width="1916" height="1072" alt="image" src="https://github.com/user-attachments/assets/0888fd55-5ef2-4401-bdb3-9dc87b7a9067" />

## Tests
<img width="1914" height="1075" alt="image" src="https://github.com/user-attachments/assets/7158fc17-d89b-498e-b1d1-28a32e776d5f" />

<img width="1898" height="1076" alt="image" src="https://github.com/user-attachments/assets/44ac34da-0be7-43d0-9d97-15d89ded63f8" />